### PR TITLE
Enable TypeScript checks in ESLint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,13 @@ module.exports = {
         'prettier/prettier': 'error',
         'no-console': 'error',
 
+        // Only show warnings for missing types
+        '@typescript-eslint/no-unsafe-argument': 'warn',
+        '@typescript-eslint/no-unsafe-assignment': 'warn',
+        '@typescript-eslint/no-unsafe-call': 'warn',
+        '@typescript-eslint/no-unsafe-member-access': 'warn',
+        '@typescript-eslint/no-unsafe-return': 'warn',
+
         // Check import or require statements are A-Z ordered
         'import/order': [
           'error',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,7 +15,7 @@ module.exports = {
         'plugin:n/recommended',
         'plugin:prettier/recommended',
         'plugin:promise/recommended',
-        'plugin:@typescript-eslint/recommended',
+        'plugin:@typescript-eslint/strict-type-checked',
         'plugin:@typescript-eslint/stylistic-type-checked',
         'prettier'
       ],
@@ -23,7 +23,8 @@ module.exports = {
       parser: '@typescript-eslint/parser',
       parserOptions: {
         ecmaVersion: 'latest',
-        project: './tsconfig.json'
+        project: true,
+        tsconfigRootDir: __dirname
       },
       plugins: [
         '@typescript-eslint',

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -66,8 +66,8 @@ jobs:
           - description: ESLint
             run: npm run lint:js
 
-          # - description: TypeScript compiler
-          #   run: npm run lint:types
+          - description: TypeScript compiler
+            run: npm run lint:types
 
           - description: Unit tests
             run: npm run test

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format": "prettier --write \"**/*.{cjs,js,json,md,mjs}\"",
     "format:check": "prettier --check \"**/*.{cjs,js,json,md,mjs}\"",
     "postinstall": "npm run setup:husky",
-    "lint": "npm run lint:js",
+    "lint": "npm run lint:js && npm run lint:types",
     "lint:fix": "eslint . --fix",
     "lint:js": "eslint .",
     "lint:types": "tsc --noEmit",

--- a/src/api/forms/errors.js
+++ b/src/api/forms/errors.js
@@ -17,7 +17,7 @@ export class ApplicationError extends Error {
    */
   constructor(message, options = {}) {
     super(message, options)
-    if (options?.statusCode) {
+    if (options.statusCode) {
       this.statusCode = options.statusCode
     }
   }

--- a/src/api/forms/form-definition-repository.js
+++ b/src/api/forms/form-definition-repository.js
@@ -16,7 +16,7 @@ function getFormDefinitionFilename(formId) {
 
 /**
  * Adds a form to the Form Store
- * @param {import('../types.js').FormConfiguration} formConfiguration - form configuration
+ * @param {FormConfiguration} formConfiguration - form configuration
  * @param {object} formDefinition - form definition (JSON object)
  */
 export async function create(formConfiguration, formDefinition) {
@@ -37,3 +37,7 @@ export async function create(formConfiguration, formDefinition) {
 export function get(formId) {
   return readFile(getFormDefinitionFilename(formId), 'utf-8').then(JSON.parse)
 }
+
+/**
+ * @typedef {import('../types.js').FormConfiguration} FormConfiguration
+ */

--- a/src/api/forms/form-definition-repository.js
+++ b/src/api/forms/form-definition-repository.js
@@ -35,6 +35,7 @@ export function create(formConfiguration, formDefinition) {
  * @returns {Promise<FormDefinition>} - form definition JSON content
  */
 export function get(formId) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Allow JSON type 'any'
   return readFile(getFormDefinitionFilename(formId), 'utf-8').then(JSON.parse)
 }
 

--- a/src/api/forms/form-definition-repository.js
+++ b/src/api/forms/form-definition-repository.js
@@ -19,20 +19,20 @@ function getFormDefinitionFilename(formId) {
  * @param {FormConfiguration} formConfiguration - form configuration
  * @param {object} formDefinition - form definition (JSON object)
  */
-export async function create(formConfiguration, formDefinition) {
+export function create(formConfiguration, formDefinition) {
   const formDefinitionFilename = getFormDefinitionFilename(formConfiguration.id)
 
   // Convert formMetadata to JSON string
   const formDefinitionString = JSON.stringify(formDefinition)
 
   // Write formDefinition to file
-  await writeFile(formDefinitionFilename, formDefinitionString)
+  return writeFile(formDefinitionFilename, formDefinitionString)
 }
 
 /**
  * Retrieves the form definition for a given form ID
  * @param {string} formId - the ID of the form
- * @returns {Promise<string>} - form definition JSON content
+ * @returns {Promise<FormDefinition>} - form definition JSON content
  */
 export function get(formId) {
   return readFile(getFormDefinitionFilename(formId), 'utf-8').then(JSON.parse)
@@ -40,4 +40,5 @@ export function get(formId) {
 
 /**
  * @typedef {import('../types.js').FormConfiguration} FormConfiguration
+ * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
  */

--- a/src/api/forms/form-metadata-repository.js
+++ b/src/api/forms/form-metadata-repository.js
@@ -35,10 +35,9 @@ export async function list() {
  * @param {string} formId - ID of the form
  * @returns {Promise<FormConfiguration>} - form configuration
  */
-export async function get(formId) {
-  const formMetadataFilename = getFormMetadataFilename(formId)
-  const value = await readFile(formMetadataFilename, { encoding: 'utf8' })
-  return JSON.parse(value)
+export function get(formId) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Allow JSON type 'any'
+  return readFile(getFormMetadataFilename(formId), 'utf-8').then(JSON.parse)
 }
 
 /**

--- a/src/api/forms/form-metadata-repository.js
+++ b/src/api/forms/form-metadata-repository.js
@@ -21,11 +21,13 @@ const getFormMetadataFilename = (formId) => {
  * @returns {Promise<FormConfiguration[]>} - form configuration
  */
 export async function list() {
-  const files = await readdir(formDirectory)
+  const files = await readdir(formDirectory, {
+    withFileTypes: true
+  })
 
   const formIds = files
-    .filter((fileName) => fileName.includes('-metadata.json'))
-    .map((fileName) => fileName.replace('-metadata.json', ''))
+    .filter((entry) => entry.name.includes('-metadata.json'))
+    .map((entry) => entry.name.replace('-metadata.json', ''))
 
   return Promise.all(formIds.map(get))
 }

--- a/src/api/forms/form-metadata-repository.test.js
+++ b/src/api/forms/form-metadata-repository.test.js
@@ -73,9 +73,7 @@ describe('#getFormMetadata', () => {
     const result = await get(formId)
 
     expect(result).toEqual(JSON.parse(formMetadata))
-    expect(readFile).toHaveBeenCalledWith(formMetadataFilename, {
-      encoding: 'utf8'
-    })
+    expect(readFile).toHaveBeenCalledWith(formMetadataFilename, 'utf-8')
   })
 
   test('Should throw an error if form malformed', async () => {

--- a/src/api/forms/form-metadata-repository.test.js
+++ b/src/api/forms/form-metadata-repository.test.js
@@ -21,7 +21,10 @@ describe('#listForms', () => {
   })
 
   test('Should return an array of form metadata', async () => {
-    const files = ['form-1-metadata.json', 'form-2-metadata.json']
+    const files = /** @type {import('node:fs').Dirent[]} */ ([
+      { name: 'form-1-metadata.json' },
+      { name: 'form-2-metadata.json' }
+    ])
 
     const form1Metadata = JSON.stringify({ id: 'form-1', title: 'Form 1' })
     const form2Metadata = JSON.stringify({ id: 'form-2', title: 'Form 2' })
@@ -41,7 +44,10 @@ describe('#listForms', () => {
   })
 
   test('Should ignore files without "-metadata.json" suffix', async () => {
-    const files = ['form-1-metadata.json', 'form-2.json']
+    const files = /** @type {import('node:fs').Dirent[]} */ ([
+      { name: 'form-1-metadata.json' },
+      { name: 'form-2.json' }
+    ])
 
     jest.mocked(readdir).mockResolvedValue(files)
     jest.mocked(readFile).mockResolvedValue(

--- a/src/api/forms/index.js
+++ b/src/api/forms/index.js
@@ -61,8 +61,8 @@ export const forms = {
 }
 
 /**
- * @typedef {import('@hapi/hapi').ServerRegisterPluginObject<void, void>} ServerRegisterPlugin
  * @typedef {import('../types.js').FormConfigurationInput} FormConfigurationInput
+ * @typedef {import('@hapi/hapi').ServerRegisterPluginObject<void, void>} ServerRegisterPlugin
  * @typedef {import('@hapi/hapi').ServerRoute<{ Params: { id: string } }>} RouteFormById
  * @typedef {import('@hapi/hapi').ServerRoute<{ Payload: FormConfigurationInput }>} RouteFormCreation
  */

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -119,6 +119,7 @@ async function retrieveEmptyForm() {
       )
     }
 
+    // @ts-expect-error Allow missing fees, outputs, feeOptions in empty form
     return emptyForm
   } catch (cause) {
     throw new InvalidFormDefinitionError(

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -74,7 +74,7 @@ export function getForm(formId) {
 /**
  * Retrieves the form definition for a given form ID
  * @param {string} formId - the ID of the form
- * @returns {Promise<string>} - form definition JSON content
+ * @returns {Promise<FormDefinition>} - form definition JSON content
  */
 export function getFormDefinition(formId) {
   return formDefinition.get(formId)
@@ -96,7 +96,7 @@ function formTitleToId(formTitle) {
 
 /**
  * Retrieves the empty form configuration
- * @returns {Promise<object>} - the empty form configuration
+ * @returns {Promise<FormDefinition>} - the empty form configuration
  * @throws {InvalidFormDefinitionError} - if the base form definition is invalid
  */
 async function retrieveEmptyForm() {
@@ -106,7 +106,9 @@ async function retrieveEmptyForm() {
   )
 
   try {
-    const emptyForm = JSON.parse(fileContent)
+    const emptyForm = /** @type {import('./empty-form.json')} */ (
+      JSON.parse(fileContent)
+    )
 
     const validationResult = Schema.validate(emptyForm)
 
@@ -128,4 +130,5 @@ async function retrieveEmptyForm() {
 /**
  * @typedef {import('../types.js').FormConfiguration} FormConfiguration
  * @typedef {import('../types.js').FormConfigurationInput} FormConfigurationInput
+ * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
  */

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -106,6 +106,7 @@ async function retrieveEmptyForm() {
   )
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Allow JSON type 'any'
     const emptyForm = /** @type {import('./empty-form.json')} */ (
       JSON.parse(fileContent)
     )

--- a/src/api/health/controller.test.js
+++ b/src/api/health/controller.test.js
@@ -7,6 +7,7 @@ describe('#healthController', () => {
   }
 
   test('Should provide expected response', () => {
+    // @ts-expect-error Allow null value for Hapi request
     healthController.handler(null, mockViewHandler)
 
     expect(mockViewHandler.response).toHaveBeenCalledWith({

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -66,15 +66,13 @@ export const config = convict({
   httpProxy: {
     doc: 'HTTP Proxy',
     format: String,
-    nullable: true,
-    default: null,
+    default: '',
     env: 'CDP_HTTP_PROXY'
   },
   httpsProxy: {
     doc: 'HTTPS Proxy',
     format: String,
-    nullable: true,
-    default: null,
+    default: '',
     env: 'CDP_HTTPS_PROXY'
   },
   formDirectory: {

--- a/src/helpers/db/populate-db.js
+++ b/src/helpers/db/populate-db.js
@@ -13,6 +13,7 @@ export const populateDb = {
     name: 'Populate Db',
     async register(server) {
       try {
+        // @ts-expect-error Allow untyped server properties
         await populateApi(server.mongoClient, server.db)
       } catch (error) {
         logger.error(error)

--- a/src/helpers/mongodb.js
+++ b/src/helpers/mongodb.js
@@ -9,18 +9,18 @@ export const mongoPlugin = {
   name: 'mongodb',
   version: '1.0.0',
   async register(server) {
-    const mongoOptions = {
-      retryWrites: false,
-      readPreference: 'secondary',
-      ...(server.secureContext && { secureContext: server.secureContext })
-    }
-
     const mongoUrl = config.get('mongoUri')
     const databaseName = config.get('mongoDatabase')
 
     server.logger.info('Setting up mongodb')
 
-    const client = await MongoClient.connect(mongoUrl.toString(), mongoOptions)
+    const client = await MongoClient.connect(mongoUrl.toString(), {
+      retryWrites: false,
+      readPreference: 'secondary',
+      // @ts-expect-error Allow untyped server properties
+      secureContext: server.secureContext || undefined
+    })
+
     const db = client.db(databaseName)
     await createIndexes(db)
 

--- a/src/helpers/mongodb.js
+++ b/src/helpers/mongodb.js
@@ -26,9 +26,9 @@ export const mongoPlugin = {
 
     server.logger.info(`mongodb connected to ${databaseName}`)
 
-    server.decorate('server', 'mongoClient', client)
-    server.decorate('server', 'db', db)
-    server.decorate('request', 'db', db)
+    server.decorate('server', 'mongoClient', () => client, { apply: true })
+    server.decorate('server', 'db', () => db, { apply: true })
+    server.decorate('request', 'db', () => db, { apply: true })
   }
 }
 

--- a/src/helpers/secure-context/secure-context.js
+++ b/src/helpers/secure-context/secure-context.js
@@ -27,7 +27,9 @@ export const secureContext = {
         return secureContext
       }
 
-      server.decorate('server', 'secureContext', tls.createSecureContext())
+      server.decorate('server', 'secureContext', tls.createSecureContext, {
+        apply: true
+      })
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "checkJs": true,
     "module": "NodeNext",
     "noEmit": true,
+    "resolveJsonModule": true,
     "strict": true,
     "target": "es2022",
     "baseUrl": "./",


### PR DESCRIPTION
This PR enables stricter type checks in ESLint, for example types must be compatible:

```patch
 /**
  * Retrieves the form definition for a given form ID
  * @param {string} formId - the ID of the form
- * @returns {Promise<string>} - form definition JSON content
+ * @returns {Promise<FormDefinition>} - form definition JSON content
  */
 export function getFormDefinition(formId) {
   return formDefinition.get(formId)
 }
```