### PR TITLE
Remove app path prefix

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -57,9 +57,7 @@ export async function createServer() {
   // Temporarily disabled. Will be restored in task #335165
   // await server.register({ plugin: mongoPlugin, options: {} })
 
-  await server.register(router, {
-    routes: { prefix: config.get('appPathPrefix') }
-  })
+  await server.register(router)
 
   // Temporarily disabled. Will be restored in task #335165
   // await server.register(populateDb)

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -26,11 +26,6 @@ export const config = convict({
     format: String,
     default: cwd()
   },
-  appPathPrefix: {
-    doc: 'Application url path prefix',
-    format: String,
-    default: '/forms-manager'
-  },
   isProduction: {
     doc: 'If this application running in the production environment',
     format: Boolean,

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -92,7 +92,7 @@ export const config = convict({
   s3Region: {
     doc: 'S3 region for the app on CDP',
     format: String,
-    default: 'us-west-2',
+    default: 'eu-west-2',
     env: 'S3_REGION'
   },
   s3Endpoint: {

--- a/src/server.js
+++ b/src/server.js
@@ -19,8 +19,6 @@ export async function listen() {
 
   server.logger.info('Server started successfully')
   server.logger.info(
-    `Access your backend on http://localhost:${config.get('port')}${config.get(
-      'appPathPrefix'
-    )}`
+    `Access your backend on http://localhost:${config.get('port')}`
   )
 }


### PR DESCRIPTION
CDP now includes the service name as a subdomain, rather than in the route.  This PR removes the redundant app path prefix.

Old URL: https://forms-manager.dev.cdp-int.defra.cloud/forms-manager
New URL: https://forms-manager.dev.cdp-int.defra.cloud/