### PR TITLE
Skip `prestart` build script on Docker start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ ARG PORT
 ENV PORT ${PORT}
 EXPOSE ${PORT}
 
-CMD [ "node", "--enable-source-maps", "./.server" ]
+CMD [ "npm", "start", "--ignore-scripts" ]


### PR DESCRIPTION
The Docker container already has "the build" so we can skip the `prestart` build script