### PR TITLE
Forms in draft status

### DIFF
--- a/src/api/forms/draft-form-definition-repository.js
+++ b/src/api/forms/draft-form-definition-repository.js
@@ -20,7 +20,7 @@ const formBucketName = config.get('formDefinitionBucketName')
 function getFormDefinitionFilename(formId) {
   const formDirectory = config.get('formDirectory')
 
-  return join(formDirectory, `${formId}.json`)
+  return join(formDirectory, 'draft', `${formId}.json`)
 }
 
 /**

--- a/src/api/forms/draft-form-definition-repository.test.js
+++ b/src/api/forms/draft-form-definition-repository.test.js
@@ -9,8 +9,11 @@ import {
 import { sdkStreamMixin } from '@smithy/util-stream'
 import { mockClient } from 'aws-sdk-client-mock'
 
+import {
+  create,
+  get
+} from '~/src/api/forms/draft-form-definition-repository.js'
 import { FailedToReadFormError } from '~/src/api/forms/errors.js'
-import { create, get } from '~/src/api/forms/form-definition-repository.js'
 
 const s3Mock = mockClient(S3Client)
 const id = '661e4ca5039739ef2902b214'

--- a/src/api/forms/draft-form-definition-repository.test.js
+++ b/src/api/forms/draft-form-definition-repository.test.js
@@ -9,10 +9,7 @@ import {
 import { sdkStreamMixin } from '@smithy/util-stream'
 import { mockClient } from 'aws-sdk-client-mock'
 
-import {
-  create,
-  get
-} from '~/src/api/forms/draft-form-definition-repository.js'
+import * as draftFormDefinition from '~/src/api/forms/draft-form-definition-repository.js'
 import { FailedToReadFormError } from '~/src/api/forms/errors.js'
 
 const s3Mock = mockClient(S3Client)
@@ -66,7 +63,7 @@ describe('Create forms in S3', () => {
   })
 
   test('test upload to s3 works', async () => {
-    await create(id, dummyFormDefinition)
+    await draftFormDefinition.create(id, dummyFormDefinition)
 
     expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(1)
   })
@@ -84,7 +81,7 @@ describe('Get forms from S3', () => {
 
     s3Mock.on(GetObjectCommand).resolvesOnce({ Body: sdkStreamMixin(stream) })
 
-    const result = get('any-form-id')
+    const result = draftFormDefinition.get('any-form-id')
 
     await expect(result).resolves.toStrictEqual(dummyFormDefinition)
   })
@@ -92,7 +89,7 @@ describe('Get forms from S3', () => {
   test('should throw FailedToReadFormError if form definition is empty', async () => {
     s3Mock.on(GetObjectCommand).resolvesOnce({ Body: undefined })
 
-    await expect(() => get('any-form-id')).rejects.toThrow(
+    await expect(() => draftFormDefinition.get('any-form-id')).rejects.toThrow(
       FailedToReadFormError
     )
   })
@@ -102,7 +99,7 @@ describe('Get forms from S3', () => {
       .on(GetObjectCommand)
       .rejectsOnce(new NoSuchKey({ $metadata: {}, message: 'dummy error' }))
 
-    await expect(() => get('any-form-id')).rejects.toThrow(
+    await expect(() => draftFormDefinition.get('any-form-id')).rejects.toThrow(
       FailedToReadFormError
     )
   })
@@ -110,7 +107,9 @@ describe('Get forms from S3', () => {
   test('should throw error if an unexpected error occurs', async () => {
     s3Mock.on(GetObjectCommand).rejectsOnce(new Error())
 
-    await expect(() => get('any-form-id')).rejects.toThrow(Error)
+    await expect(() => draftFormDefinition.get('any-form-id')).rejects.toThrow(
+      Error
+    )
   })
 })
 

--- a/src/api/forms/errors.js
+++ b/src/api/forms/errors.js
@@ -46,6 +46,21 @@ export class FailedCreationOperationError extends ApplicationError {
 }
 
 /**
+ * Indicates that the requested resource was not found.
+ */
+export class ResourceNotFoundError extends ApplicationError {
+  name = 'ResourceNotFoundError'
+
+  /**
+   * Constructs the error
+   * @param {string} message - the message to report
+   */
+  constructor(message) {
+    super(message, { statusCode: 404 })
+  }
+}
+
+/**
  * Indicates the form already exists so cannot be created again.
  */
 export class FormAlreadyExistsError extends ApplicationError {

--- a/src/api/forms/form-metadata-repository.js
+++ b/src/api/forms/form-metadata-repository.js
@@ -30,6 +30,15 @@ export function get(formId) {
 }
 
 /**
+ * Retrieves a document from the database
+ * @param {string} formId - ID of the form
+ * @returns {Promise<boolean>} if the ID exists or not
+ */
+export async function exists(formId) {
+  return !!(await get(formId))
+}
+
+/**
  * Create a document in the database
  * @param {FormMetadataDocument} document - form metadata document
  */

--- a/src/api/forms/form-metadata-repository.js
+++ b/src/api/forms/form-metadata-repository.js
@@ -18,7 +18,7 @@ export function list() {
 }
 
 /**
- * Retrieves a document from the database
+ * Retrieves a form metadata
  * @param {string} formId - ID of the form
  */
 export function get(formId) {
@@ -27,15 +27,6 @@ export function get(formId) {
   )
 
   return coll.findOne({ _id: new ObjectId(formId) })
-}
-
-/**
- * Retrieves a document from the database
- * @param {string} formId - ID of the form
- * @returns {Promise<boolean>} if the ID exists or not
- */
-export async function exists(formId) {
-  return !!(await get(formId))
 }
 
 /**

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -97,7 +97,9 @@ export function getDraftFormDefinition(formId) {
  * @param {FormDefinition} formDefinition - full JSON form definition
  */
 export async function updateDraftFormDefinition(formId, formDefinition) {
-  if (!(await formMetadata.exists(formId))) {
+  const existingForm = await getForm(formId)
+
+  if (!existingForm) {
     throw new ResourceNotFoundError(
       `Form ${formId} does not exist, so the definition cannot be updated.`
     )

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -92,7 +92,6 @@ export function getDraftFormDefinition(formId) {
 }
 
 /**
- *
  * @param {string} formId - ID of the form
  * @param {FormDefinition} formDefinition - full JSON form definition
  */

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -1,5 +1,8 @@
 import * as draftFormDefinition from '~/src/api/forms/draft-form-definition-repository.js'
-import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
+import {
+  InvalidFormDefinitionError,
+  ResourceNotFoundError
+} from '~/src/api/forms/errors.js'
 import * as formMetadata from '~/src/api/forms/form-metadata-repository.js'
 import * as formTemplates from '~/src/api/forms/templates.js'
 import { formDefinitionSchema } from '~/src/models/forms.js'
@@ -93,7 +96,13 @@ export function getDraftFormDefinition(formId) {
  * @param {string} formId - ID of the form
  * @param {FormDefinition} formDefinition - full JSON form definition
  */
-export function updateDraftFormDefinition(formId, formDefinition) {
+export async function updateDraftFormDefinition(formId, formDefinition) {
+  if (!(await formMetadata.exists(formId))) {
+    throw new ResourceNotFoundError(
+      `Form ${formId} does not exist, so the definition cannot be updated.`
+    )
+  }
+
   return draftFormDefinition.create(formId, formDefinition)
 }
 

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -121,8 +121,8 @@ function formTitleToSlug(title) {
 }
 
 /**
- * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
- * @typedef {import('./errors.js').FormAlreadyExistsError} FormAlreadyExistsError
+ * @typedef {import('~/src/api/forms/errors.js').FormAlreadyExistsError} FormAlreadyExistsError
+ * @typedef {import('~/src/api/types.js').FormDefinition} FormDefinition
  * @typedef {import('../types.js').FormMetadata} FormMetadata
  * @typedef {import('../types.js').FormMetadataDocument} FormMetadataDocument
  * @typedef {import('../types.js').FormMetadataInput} FormMetadataInput

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -1,5 +1,5 @@
+import * as draftFormDefinition from '~/src/api/forms/draft-form-definition-repository.js'
 import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
-import * as formDefinition from '~/src/api/forms/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/form-metadata-repository.js'
 import * as formTemplates from '~/src/api/forms/templates.js'
 import { formDefinitionSchema } from '~/src/models/forms.js'
@@ -53,7 +53,7 @@ export async function createForm(formMetadataInput) {
   const { insertedId: _id } = await formMetadata.create(document)
 
   // Create the form definition
-  await formDefinition.create(_id.toString(), definition)
+  await draftFormDefinition.create(_id.toString(), definition)
 
   return mapForm({ ...document, _id })
 }
@@ -84,8 +84,17 @@ export async function getForm(formId) {
  * @param {string} formId - the ID of the form
  * @throws {FailedToReadFormError} - if the file does not exist or is empty
  */
-export function getFormDefinition(formId) {
-  return formDefinition.get(formId)
+export function getDraftFormDefinition(formId) {
+  return draftFormDefinition.get(formId)
+}
+
+/**
+ *
+ * @param {string} formId - ID of the form
+ * @param {FormDefinition} formDefinition - full JSON form definition
+ */
+export function updateDraftFormDefinition(formId, formDefinition) {
+  return draftFormDefinition.create(formId, formDefinition)
 }
 
 /**
@@ -102,6 +111,7 @@ function formTitleToSlug(title) {
 }
 
 /**
+ * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
  * @typedef {import('./errors.js').FormAlreadyExistsError} FormAlreadyExistsError
  * @typedef {import('../types.js').FormMetadata} FormMetadata
  * @typedef {import('../types.js').FormMetadataDocument} FormMetadataDocument

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -133,7 +133,7 @@ describe('createForm', () => {
   })
 
   it('should throw an error if the form associated with the definition does not exist', async () => {
-    jest.mocked(draftFormDefinition.get).mockResolvedValueOnce(null)
+    jest.mocked(draftFormDefinition.get).mockRejectedValue(new Error())
 
     await expect(
       updateDraftFormDefinition('123', actualEmptyForm())

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -1,9 +1,16 @@
 import { ObjectId } from 'mongodb'
 
 import * as draftFormDefinition from '~/src/api/forms/draft-form-definition-repository.js'
-import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
+import {
+  InvalidFormDefinitionError,
+  ResourceNotFoundError
+} from '~/src/api/forms/errors.js'
 import * as formMetadata from '~/src/api/forms/form-metadata-repository.js'
-import { createForm } from '~/src/api/forms/service.js'
+import {
+  createForm,
+  getDraftFormDefinition,
+  updateDraftFormDefinition
+} from '~/src/api/forms/service.js'
 import * as formTemplates from '~/src/api/forms/templates.js'
 
 jest.mock('~/src/api/forms/draft-form-definition-repository.js')
@@ -113,5 +120,24 @@ describe('createForm', () => {
     }
 
     await expect(createForm(formMetadataInput)).rejects.toThrow(Error)
+  })
+
+  it('should return the form definition', async () => {
+    jest.mocked(formMetadata.exists).mockResolvedValueOnce(true)
+    jest
+      .mocked(draftFormDefinition.get)
+      .mockResolvedValueOnce(actualEmptyForm())
+
+    await expect(getDraftFormDefinition('123')).resolves.toMatchObject(
+      actualEmptyForm()
+    )
+  })
+
+  it('should throw an error if the form associated with the definition does not exist', async () => {
+    jest.mocked(formMetadata.exists).mockResolvedValueOnce(false)
+
+    await expect(
+      updateDraftFormDefinition('123', actualEmptyForm())
+    ).rejects.toThrow(ResourceNotFoundError)
   })
 })

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -123,10 +123,9 @@ describe('createForm', () => {
   })
 
   it('should return the form definition', async () => {
-    jest.mocked(formMetadata.exists).mockResolvedValueOnce(true)
-    jest
-      .mocked(draftFormDefinition.get)
-      .mockResolvedValueOnce(actualEmptyForm())
+    const formDef = actualEmptyForm()
+
+    jest.mocked(draftFormDefinition.get).mockResolvedValueOnce(formDef)
 
     await expect(getDraftFormDefinition('123')).resolves.toMatchObject(
       actualEmptyForm()
@@ -134,7 +133,7 @@ describe('createForm', () => {
   })
 
   it('should throw an error if the form associated with the definition does not exist', async () => {
-    jest.mocked(formMetadata.exists).mockResolvedValueOnce(false)
+    jest.mocked(draftFormDefinition.get).mockResolvedValueOnce(null)
 
     await expect(
       updateDraftFormDefinition('123', actualEmptyForm())

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -1,12 +1,12 @@
 import { ObjectId } from 'mongodb'
 
+import * as draftFormDefinition from '~/src/api/forms/draft-form-definition-repository.js'
 import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
-import * as formDefinition from '~/src/api/forms/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/form-metadata-repository.js'
 import { createForm } from '~/src/api/forms/service.js'
 import * as formTemplates from '~/src/api/forms/templates.js'
 
-jest.mock('~/src/api/forms/form-definition-repository.js')
+jest.mock('~/src/api/forms/draft-form-definition-repository.js')
 jest.mock('~/src/api/forms/form-metadata-repository.js')
 jest.mock('~/src/api/forms/templates.js')
 
@@ -21,8 +21,8 @@ describe('createForm', () => {
   beforeEach(() => {
     id = '661e4ca5039739ef2902b214'
 
+    jest.mocked(draftFormDefinition.create).mockResolvedValue()
     jest.mocked(formTemplates.empty).mockReturnValue(actualEmptyForm())
-    jest.mocked(formDefinition.create).mockResolvedValue()
     jest.mocked(formMetadata.create).mockResolvedValue({
       acknowledged: true,
       insertedId: new ObjectId(id)
@@ -103,7 +103,7 @@ describe('createForm', () => {
   })
 
   it('should throw an error when writing form def fails', async () => {
-    jest.mocked(formDefinition.create).mockRejectedValueOnce(new Error())
+    jest.mocked(draftFormDefinition.create).mockRejectedValueOnce(new Error())
 
     const formMetadataInput = {
       title: 'My Form',

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -24,6 +24,7 @@
 /**
  * Form API request types
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput }>} RequestFormById
+ * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: FormDefinition }>} RequestFormDefinition
  * @typedef {Request<{ Server: { db: Db }, Payload: FormMetadataInput }>} RequestFormMetadata
  */
 

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -6,9 +6,14 @@ import {
   listForms,
   getForm,
   createForm,
-  getFormDefinition
+  updateDraftFormDefinition,
+  getDraftFormDefinition
 } from '~/src/api/forms/service.js'
-import { formMetadataSchema, formByIdSchema } from '~/src/models/forms.js'
+import {
+  formMetadataSchema,
+  formByIdSchema,
+  formDefinitionSchema
+} from '~/src/models/forms.js'
 
 /**
  * @type {ServerRoute[]}
@@ -68,7 +73,7 @@ export default [
   },
   {
     method: 'GET',
-    path: '/forms/{id}/definition',
+    path: '/forms/{id}/definition/draft',
     /**
      * @param {RequestFormById} request
      */
@@ -77,7 +82,7 @@ export default [
       const { id } = params
 
       try {
-        const definition = await getFormDefinition(id)
+        const definition = await getDraftFormDefinition(id)
 
         return definition
       } catch (err) {
@@ -93,11 +98,34 @@ export default [
         params: formByIdSchema
       }
     }
+  },
+  {
+    method: 'POST',
+    path: '/forms/{id}/definition/draft',
+    /**
+     * @param {RequestFormDefinition} request
+     */
+    async handler(request) {
+      const { params, payload } = request
+
+      await updateDraftFormDefinition(params.id, payload)
+
+      return {
+        id: params.id,
+        status: 'updated'
+      }
+    },
+    options: {
+      validate: {
+        payload: formDefinitionSchema
+      }
+    }
   }
 ]
 
 /**
  * @typedef {import('@hapi/hapi').ServerRoute} ServerRoute
  * @typedef {import('../api/types.js').RequestFormById} RequestFormById
+ * @typedef {import('../api/types.js').RequestFormDefinition} RequestFormDefinition
  * @typedef {import('../api/types.js').RequestFormMetadata} RequestFormMetadata
  */

--- a/src/routes/forms.test.js
+++ b/src/routes/forms.test.js
@@ -7,7 +7,7 @@ import {
   listForms,
   createForm,
   getForm,
-  getFormDefinition
+  getDraftFormDefinition
 } from '~/src/api/forms/service.js'
 import { createServer } from '~/src/api/server.js'
 
@@ -128,12 +128,12 @@ describe('Forms route', () => {
       expect(response.result).toEqual(stubFormOutput)
     })
 
-    test('Testing GET /forms/{id}/definition route returns a form definition', async () => {
-      jest.mocked(getFormDefinition).mockResolvedValue(stubFormDefinition)
+    test('Testing GET /forms/{id}/definition/draft route returns a form definition', async () => {
+      jest.mocked(getDraftFormDefinition).mockResolvedValue(stubFormDefinition)
 
       const response = await server.inject({
         method: 'GET',
-        url: `/forms/${id}/definition`
+        url: `/forms/${id}/definition/draft`
       })
 
       expect(response.statusCode).toEqual(okStatusCode)
@@ -435,10 +435,10 @@ describe('Forms route', () => {
       })
     })
 
-    test('Testing GET /forms/{id}/definition route with an invalid id returns validation errors', async () => {
+    test('Testing GET /forms/{id}/definition/draft route with an invalid id returns validation errors', async () => {
       const response = await server.inject({
         method: 'GET',
-        url: '/forms/1/definition'
+        url: '/forms/1/definition/draft'
       })
 
       expect(response.statusCode).toEqual(badRequestStatusCode)
@@ -454,10 +454,10 @@ describe('Forms route', () => {
       })
     })
 
-    test('Testing GET /forms/{id}/definition route with an invalid id returns validation errors', async () => {
+    test('Testing GET /forms/{id}/definition/draft route with an invalid id returns validation errors', async () => {
       const response = await server.inject({
         method: 'GET',
-        url: `/forms/${'x'.repeat(24)}/definition`
+        url: `/forms/${'x'.repeat(24)}/definition/draft`
       })
 
       expect(response.statusCode).toEqual(badRequestStatusCode)
@@ -473,14 +473,14 @@ describe('Forms route', () => {
       })
     })
 
-    test('Testing GET /forms/{id}/definition route with an id that is not found returns 404 Not found', async () => {
-      jest.mocked(getFormDefinition).mockImplementation(() => {
-        throw new FailedToReadFormError('Failed')
-      })
+    test('Testing GET /forms/{id}/definition/draft route with an id that is not found returns 404 Not found', async () => {
+      jest
+        .mocked(getDraftFormDefinition)
+        .mockRejectedValue(new FailedToReadFormError('Failed'))
 
       const response = await server.inject({
         method: 'GET',
-        url: `/forms/${id}/definition`
+        url: `/forms/${id}/definition/draft`
       })
 
       expect(response.statusCode).toEqual(notFoundStatusCode)
@@ -492,14 +492,14 @@ describe('Forms route', () => {
       })
     })
 
-    test('Testing GET /forms/{id}/definition route throws unknown error', async () => {
-      jest.mocked(getFormDefinition).mockImplementation(() => {
-        throw new Error('Unknown error')
-      })
+    test('Testing GET /forms/{id}/definition/draft route throws unknown error', async () => {
+      jest
+        .mocked(getDraftFormDefinition)
+        .mockRejectedValue(new Error('Unknown error'))
 
       const response = await server.inject({
         method: 'GET',
-        url: `/forms/${id}/definition`
+        url: `/forms/${id}/definition/draft`
       })
 
       expect(response.statusCode).toEqual(internalErrorStatusCode)


### PR DESCRIPTION
Switch form definition to "draft" form definition. Later ticket will add a promotion process for draft->live.

Adds a new endpoint to update the draft form definition so the form editor can update the state as the user makes changes.

I've renamed the repository for form definitions to include `drafts`, the refactoring of that to support live forms will happen later - not required at present.