### PR TITLE
Add required region/location flags for `create-bucket` docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ npm ci
 
 ```bash
 localstack start
-awslocal s3api create-bucket --bucket form-definition-storage
+awslocal s3api create-bucket \
+  --bucket form-definition-storage \
+  --region eu-west-2 \
+  --create-bucket-configuration LocationConstraint=eu-west-2
 ```
 
 5. Add your bucket name into your .env file:


### PR DESCRIPTION
Two extra flags needed when the region isn't `us-east-1` to avoid this error:

```console
An error occurred (IllegalLocationConstraintException) when calling the CreateBucket operation: The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.
```

The change was taken from the [CLI examples page](https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html#examples):

<br>

>### Example 3: To create a bucket outside of the `us-east-1` region
>
>The following `create-bucket` example creates a bucket named `my-bucket` in the `eu-west-1` region. Regions outside of >`us-east-1` require the appropriate `LocationConstraint` to be specified in order to create the bucket in the desired >region.
>
>```
>aws s3api create-bucket \
>    --bucket my-bucket \
>    --region eu-west-1 \
>    --create-bucket-configuration LocationConstraint=eu-west-1
>```
