### PR TITLE
Add aws4, an optional dependency of the mongo driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@defra/forms-model": "^3.0.39",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.3.3",
+        "aws4": "^1.12.0",
         "convict": "^6.2.4",
         "dotenv": "^16.4.5",
         "hapi-pino": "^12.1.0",
@@ -6105,6 +6106,11 @@
         "sinon": "^16.1.3",
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@defra/forms-model": "^3.0.39",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.3.3",
+    "aws4": "^1.12.0",
     "convict": "^6.2.4",
     "dotenv": "^16.4.5",
     "hapi-pino": "^12.1.0",


### PR DESCRIPTION
`aws4` is an optional dependency of the native Mongodb driver.
Being optional, it is not included in their package.json, and you are expected to install it on the application level.

https://www.mongodb.com/docs/drivers/node/current/fundamentals/authentication/mechanisms/#mongodb-aws