### PR TITLE
Only allow “approved” Slack code review comments

### DIFF
--- a/.github/workflows/pr-notifier.yml
+++ b/.github/workflows/pr-notifier.yml
@@ -50,6 +50,7 @@ jobs:
     steps:
       - name: Post to Slack
         uses: slackapi/slack-github-action@v1.26.0
+        if: github.event.action != 'submitted' || github.event.review.state == 'approved'
 
         env:
           ACTION_ICON: ${{ fromJSON(env.CONFIG)[github.event.action].icon }}


### PR DESCRIPTION
This PR skips the `pull_request_review` event for individual comments and replies

It's a bit noisy adding Slack comments for all code review comments