### PR TITLE
Ensure form objects have required properties

### DIFF
--- a/src/api/forms/empty-form.js
+++ b/src/api/forms/empty-form.js
@@ -1,15 +1,16 @@
 /**
  * Function to return an empty form
- * @returns {object} - the empty form
  */
 export function emptyForm() {
-  return {
+  return /** @satisfies {FormDefinition} */ ({
     name: '',
     startPage: '/page-one',
     pages: [
       {
         path: '/page-one',
         title: 'Page one',
+        controller: './pages/summary.js',
+        section: 'section',
         components: [
           {
             type: 'TextField',
@@ -23,7 +24,24 @@ export function emptyForm() {
       }
     ],
     conditions: [],
-    sections: [],
-    lists: []
-  }
+    sections: [
+      {
+        name: 'section',
+        title: 'Section title',
+        hideTitle: false
+      }
+    ],
+    lists: [],
+    feeOptions: {
+      maxAttempts: 1,
+      showPaymentSkippedWarningPage: false,
+      allowSubmissionWithoutPayment: true
+    },
+    fees: [],
+    outputs: []
+  })
 }
+
+/**
+ * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
+ */

--- a/src/api/forms/form-definition-repository.js
+++ b/src/api/forms/form-definition-repository.js
@@ -27,7 +27,7 @@ function getFormDefinitionFilename(formId) {
 /**
  * Adds a form to the Form Store
  * @param {string} id - id
- * @param {object} formDefinition - form definition (JSON object)
+ * @param {FormDefinition} formDefinition - form definition (JSON object)
  */
 export function create(id, formDefinition) {
   const formDefinitionFilename = getFormDefinitionFilename(id)

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -90,6 +90,7 @@ describe('createForm', () => {
   })
 
   it('should throw an error when schema validation fails', async () => {
+    // @ts-expect-error - Allow invalid form definition for test
     jest.mocked(emptyForm).mockReturnValueOnce({})
     jest.mocked(formMetadataCreate).mockImplementationOnce(mockFormMetadataImpl)
     // @ts-expect-error unused response type so ignore type for now

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -13,7 +13,7 @@
  * @typedef {Omit<FormConfigurationDocumentInput, 'slug'>} FormConfigurationInput
  * @typedef {Request<{ Server: { db: import('mongodb').Db } }>} RequestDefaults
  * @typedef {RequestDefaults & Request<{ Params: { id: string } }>} RequestFormById
- * @typedef {RequestDefaults & Request<{ Payload: FormConfigurationInput }>} RequestFormCreation
+ * @typedef {RequestDefaults & Request<{ Payload: FormConfigurationInput }>} RequestCreateForm
  */
 
 /**

--- a/src/models/forms.js
+++ b/src/models/forms.js
@@ -1,21 +1,9 @@
 import Joi from 'joi'
 
-// Mongo id
-export const idStringSchema = Joi.string().hex().length(24)
-
-// Mongo id object
-export const idObjectSchema = Joi.object().keys({
-  id: Joi.any(),
-  _bsontype: Joi.allow('ObjectId')
-})
-
-// Alternative Mongo id object
-export const idSchema = Joi.alternatives(idStringSchema, idObjectSchema)
-
 // Retrieve form by ID schema
 export const formByIdSchema = Joi.object()
   .keys({
-    id: idStringSchema
+    id: Joi.string().hex().length(24)
   })
   .required()
 

--- a/src/models/forms.js
+++ b/src/models/forms.js
@@ -12,8 +12,8 @@ export const idObjectSchema = Joi.object().keys({
 // Alternative Mongo id object
 export const idSchema = Joi.alternatives(idStringSchema, idObjectSchema)
 
-// Mongo id object params schema
-export const idParamSchema = Joi.object()
+// Retrieve form by ID schema
+export const formByIdSchema = Joi.object()
   .keys({
     id: idStringSchema
   })

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -8,7 +8,7 @@ import {
   createForm,
   getFormDefinition
 } from '~/src/api/forms/service.js'
-import { createFormSchema, idParamSchema } from '~/src/models/forms.js'
+import { createFormSchema, formByIdSchema } from '~/src/models/forms.js'
 
 /**
  * @type {ServerRoute[]}
@@ -25,7 +25,7 @@ export default [
     method: 'POST',
     path: '/forms',
     /**
-     * @param {RequestFormCreation} request
+     * @param {RequestCreateForm} request
      */
     async handler(request) {
       const { payload } = request
@@ -62,7 +62,7 @@ export default [
     },
     options: {
       validate: {
-        params: idParamSchema
+        params: formByIdSchema
       }
     }
   },
@@ -90,7 +90,7 @@ export default [
     },
     options: {
       validate: {
-        params: idParamSchema
+        params: formByIdSchema
       }
     }
   }
@@ -98,7 +98,7 @@ export default [
 
 /**
  * @typedef {import('@hapi/hapi').ServerRoute} ServerRoute
+ * @typedef {import('../api/types.js').RequestCreateForm} RequestCreateForm
  * @typedef {import('../api/types.js').RequestFormById} RequestFormById
- * @typedef {import('../api/types.js').RequestFormCreation} RequestFormCreation
  * @typedef {import('../api/types.js').FormConfigurationInput} FormConfigurationInput
  */


### PR DESCRIPTION
This PR adds the `FormDefinition` type so our form JSON is always confirmed to be valid

I've also renamed the Joi schemas to match the types