### PR TITLE
Use generics to simplify MongoDB document types

### DIFF
--- a/src/api/forms/form-definition-repository.js
+++ b/src/api/forms/form-definition-repository.js
@@ -107,6 +107,5 @@ function getS3Client() {
 }
 
 /**
- * @typedef {import('../types.js').FormConfiguration} FormConfiguration
  * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
  */

--- a/src/api/forms/form-metadata-repository.js
+++ b/src/api/forms/form-metadata-repository.js
@@ -10,11 +10,11 @@ export const MAX_RESULTS = 500
  * Retrieves the list of documents from the database
  */
 export function list() {
-  const coll = db.collection(COLLECTION_NAME)
+  const coll = /** @satisfies {Collection<FormConfigurationDocument>} */ (
+    db.collection(COLLECTION_NAME)
+  )
 
-  const res = coll.find().limit(MAX_RESULTS).toArray()
-
-  return res
+  return coll.find().limit(MAX_RESULTS).toArray()
 }
 
 /**
@@ -22,18 +22,23 @@ export function list() {
  * @param {string} formId - ID of the form
  */
 export function get(formId) {
-  const coll = db.collection(COLLECTION_NAME)
+  const coll = /** @satisfies {Collection<FormConfigurationDocument>} */ (
+    db.collection(COLLECTION_NAME)
+  )
 
   return coll.findOne({ _id: new ObjectId(formId) })
 }
 
 /**
  * Create a document in the database
- * @param {FormConfigurationDocumentInput} form - form configuration
+ * @param {FormConfigurationDocument} form - form configuration
  */
 export async function create(form) {
+  const coll = /** @satisfies {Collection<FormConfigurationDocument>} */ (
+    db.collection(COLLECTION_NAME)
+  )
+
   try {
-    const coll = db.collection(COLLECTION_NAME)
     const result = await coll.insertOne(form)
 
     return result
@@ -47,14 +52,11 @@ export async function create(form) {
 }
 
 /**
- * @typedef {import('mongodb').Document} Document
- * @typedef {import('mongodb').WithId<Document>} DocumentWithId
- * @typedef {import('mongodb').InsertOneResult} InsertOneResult
  * @typedef {import('../types.js').FormConfiguration} FormConfiguration
- * @typedef {import('../types.js').FormConfigurationDocumentInput} FormConfigurationDocumentInput
+ * @typedef {import('../types.js').FormConfigurationDocument} FormConfigurationDocument
  */
 
 /**
  * @template {object} Schema
- * @typedef {import('mongodb').WithId<Schema> | null} WithId
+ * @typedef {import('mongodb').Collection<Schema>} Collection
  */

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -140,6 +140,5 @@ describe('createForm', () => {
 })
 
 /**
- * @typedef {import('../types.js').FormConfiguration} FormConfiguration
  * @typedef {import('../types.js').FormConfigurationInput} FormConfigurationInput
  */

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -9,11 +9,11 @@
  */
 
 /**
- * @typedef {Omit<FormConfiguration, 'id'>} FormConfigurationDocumentInput
- * @typedef {Omit<FormConfigurationDocumentInput, 'slug'>} FormConfigurationInput
- * @typedef {Request<{ Server: { db: import('mongodb').Db } }>} RequestDefaults
- * @typedef {RequestDefaults & Request<{ Params: { id: string } }>} RequestFormById
- * @typedef {RequestDefaults & Request<{ Payload: FormConfigurationInput }>} RequestCreateForm
+ * @typedef {Omit<FormConfiguration, 'id'>} FormConfigurationDocument
+ * @typedef {Omit<FormConfiguration, 'id' | 'slug'>} FormConfigurationInput
+ * @typedef {Request<{ Server: { db: Db }, Params: Pick<FormConfiguration, 'id'> }>} RequestFormById
+ * @typedef {Request<{ Server: { db: Db }, Payload: FormConfigurationInput }>} RequestCreateForm
+ * @typedef {import('mongodb').Db} Db
  */
 
 /**

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -100,5 +100,4 @@ export default [
  * @typedef {import('@hapi/hapi').ServerRoute} ServerRoute
  * @typedef {import('../api/types.js').RequestCreateForm} RequestCreateForm
  * @typedef {import('../api/types.js').RequestFormById} RequestFormById
- * @typedef {import('../api/types.js').FormConfigurationInput} FormConfigurationInput
  */


### PR DESCRIPTION
This PR sets up MongoDB types `Collection` and `WithId` to use generics

This ensures our form configurations continue to be type checked for inserts and queries

```js
/**
 * @template {object} Schema
 * @typedef {import('mongodb').Collection<Schema>} Collection
 */
```

```js
/**
 * @template {object} Schema
 * @typedef {import('mongodb').WithId<Schema>} WithId
 */
```