### PR TITLE
Simplify Jest mocks for form service testing

### DIFF
--- a/src/api/forms/form-definition-repository.js
+++ b/src/api/forms/form-definition-repository.js
@@ -28,14 +28,14 @@ function getFormDefinitionFilename(formId) {
  * @param {string} id - id
  * @param {FormDefinition} formDefinition - form definition (JSON object)
  */
-export function create(id, formDefinition) {
+export async function create(id, formDefinition) {
   const formDefinitionFilename = getFormDefinitionFilename(id)
 
   // Convert formMetadata to JSON string
   const formDefinitionString = JSON.stringify(formDefinition)
 
   // Write formDefinition to file
-  return uploadToS3(formDefinitionFilename, formDefinitionString)
+  await uploadToS3(formDefinitionFilename, formDefinitionString)
 }
 
 /**

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -1,9 +1,9 @@
 import { Schema } from '@defra/forms-model'
 
-import { emptyForm } from '~/src/api/forms/empty-form.js'
 import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import * as formDefinition from '~/src/api/forms/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/form-metadata-repository.js'
+import * as formTemplates from '~/src/api/forms/templates.js'
 
 /**
  * Maps a document to a FormConfiguration
@@ -43,7 +43,7 @@ export async function createForm(formConfigurationInput) {
   const { insertedId: _id } = await formMetadata.create(document)
 
   // Create a blank form definition with the title set
-  const definition = { ...emptyForm(), name: title }
+  const definition = { ...formTemplates.empty(), name: title }
 
   // Validate the form definition
   const { error } = Schema.validate(definition)

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -1,17 +1,17 @@
 import { ObjectId } from 'mongodb'
 
-import { emptyForm } from '~/src/api/forms/empty-form.js'
 import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import { create as formDefinitionCreate } from '~/src/api/forms/form-definition-repository.js'
 import { create as formMetadataCreate } from '~/src/api/forms/form-metadata-repository.js'
 import { createForm } from '~/src/api/forms/service.js'
+import * as formTemplates from '~/src/api/forms/templates.js'
 
 jest.mock('~/src/api/forms/form-definition-repository.js')
 jest.mock('~/src/api/forms/form-metadata-repository.js')
-jest.mock('~/src/api/forms/empty-form.js')
+jest.mock('~/src/api/forms/templates.js')
 
 const id = '661e4ca5039739ef2902b214'
-const actualEmptyForm = jest.requireActual('~/src/api/forms/empty-form.js')
+const actualFormTemplates = jest.requireActual('~/src/api/forms/templates.js')
 const mockFormMetadataImpl = (/** @type {FormConfigurationInput} */ input) => {
   const objId = new ObjectId(id)
 
@@ -30,7 +30,9 @@ const mockFormMetadataImpl = (/** @type {FormConfigurationInput} */ input) => {
  * @param {FormConfigurationInput} formConfigurationInput - the input request
  */
 async function runFormCreationTest(formConfigurationInput) {
-  jest.mocked(emptyForm).mockReturnValueOnce(actualEmptyForm.emptyForm())
+  jest
+    .mocked(formTemplates.empty)
+    .mockReturnValueOnce(actualFormTemplates.empty())
   jest.mocked(formMetadataCreate).mockImplementationOnce(mockFormMetadataImpl)
   jest.mocked(formDefinitionCreate).mockResolvedValueOnce()
 
@@ -84,7 +86,7 @@ describe('createForm', () => {
 
   it('should throw an error when schema validation fails', async () => {
     // @ts-expect-error - Allow invalid form definition for test
-    jest.mocked(emptyForm).mockReturnValueOnce({})
+    jest.mocked(formTemplates.empty).mockReturnValueOnce({})
     jest.mocked(formMetadataCreate).mockImplementationOnce(mockFormMetadataImpl)
     jest.mocked(formDefinitionCreate).mockResolvedValueOnce()
 
@@ -101,7 +103,7 @@ describe('createForm', () => {
   })
 
   it('should throw an error when writing for metadata fails', async () => {
-    jest.mocked(emptyForm).mockReturnValueOnce(actualEmptyForm.emptyForm())
+    jest.mocked(emptyForm).mockReturnValueOnce(actualFormTemplates.empty())
     jest.mocked(formMetadataCreate).mockRejectedValueOnce(new Error())
     jest.mocked(formDefinitionCreate).mockResolvedValueOnce()
 
@@ -116,7 +118,7 @@ describe('createForm', () => {
   })
 
   it('should throw an error when writing form def fails', async () => {
-    jest.mocked(emptyForm).mockReturnValueOnce(actualEmptyForm.emptyForm())
+    jest.mocked(emptyForm).mockReturnValueOnce(actualFormTemplates.empty())
     jest.mocked(formMetadataCreate).mockImplementationOnce(mockFormMetadataImpl)
     jest.mocked(formDefinitionCreate).mockRejectedValueOnce(new Error())
 

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -32,9 +32,7 @@ const mockFormMetadataImpl = (/** @type {FormConfigurationInput} */ input) => {
 async function runFormCreationTest(formConfigurationInput) {
   jest.mocked(emptyForm).mockReturnValueOnce(actualEmptyForm.emptyForm())
   jest.mocked(formMetadataCreate).mockImplementationOnce(mockFormMetadataImpl)
-
-  // @ts-expect-error unused response type so ignore type for now
-  jest.mocked(formDefinitionCreate).mockResolvedValueOnce(Promise.resolve())
+  jest.mocked(formDefinitionCreate).mockResolvedValueOnce()
 
   return createForm(formConfigurationInput)
 }
@@ -88,8 +86,7 @@ describe('createForm', () => {
     // @ts-expect-error - Allow invalid form definition for test
     jest.mocked(emptyForm).mockReturnValueOnce({})
     jest.mocked(formMetadataCreate).mockImplementationOnce(mockFormMetadataImpl)
-    // @ts-expect-error unused response type so ignore type for now
-    jest.mocked(formDefinitionCreate).mockResolvedValueOnce(Promise.resolve())
+    jest.mocked(formDefinitionCreate).mockResolvedValueOnce()
 
     const formConfiguration = {
       title: 'My Form',
@@ -105,11 +102,8 @@ describe('createForm', () => {
 
   it('should throw an error when writing for metadata fails', async () => {
     jest.mocked(emptyForm).mockReturnValueOnce(actualEmptyForm.emptyForm())
-    jest.mocked(formMetadataCreate).mockImplementation(() => {
-      throw new Error()
-    })
-    // @ts-expect-error unused response type so ignore type for now
-    jest.mocked(formDefinitionCreate).mockResolvedValueOnce(Promise.resolve())
+    jest.mocked(formMetadataCreate).mockRejectedValueOnce(new Error())
+    jest.mocked(formDefinitionCreate).mockResolvedValueOnce()
 
     const formConfiguration = {
       title: 'My Form',
@@ -124,9 +118,7 @@ describe('createForm', () => {
   it('should throw an error when writing form def fails', async () => {
     jest.mocked(emptyForm).mockReturnValueOnce(actualEmptyForm.emptyForm())
     jest.mocked(formMetadataCreate).mockImplementationOnce(mockFormMetadataImpl)
-    jest.mocked(formDefinitionCreate).mockImplementation(() => {
-      throw new Error()
-    })
+    jest.mocked(formDefinitionCreate).mockRejectedValueOnce(new Error())
 
     const formConfiguration = {
       title: 'My Form',

--- a/src/api/forms/templates.js
+++ b/src/api/forms/templates.js
@@ -1,7 +1,7 @@
 /**
  * Function to return an empty form
  */
-export function emptyForm() {
+export function empty() {
   return /** @satisfies {FormDefinition} */ ({
     name: '',
     startPage: '/page-one',


### PR DESCRIPTION
This PR simplifies how we write Jest mocks

1. Removes return value from `formDefinition.create()` so we don't have to mock S3 objects
2. Renamed templates to ~`forms/empty-form.js`~ `forms/templates.js` for easier namespace mocking
