### PR TITLE
Rename “configuration” to “metadata” in comments etc

### DIFF
--- a/src/api/forms/form-definition-repository.js
+++ b/src/api/forms/form-definition-repository.js
@@ -31,7 +31,7 @@ function getFormDefinitionFilename(formId) {
 export async function create(id, formDefinition) {
   const formDefinitionFilename = getFormDefinitionFilename(id)
 
-  // Convert formMetadata to JSON string
+  // Convert form definition to JSON string
   const formDefinitionString = JSON.stringify(formDefinition)
 
   // Write formDefinition to file

--- a/src/api/forms/form-metadata-repository.js
+++ b/src/api/forms/form-metadata-repository.js
@@ -31,20 +31,20 @@ export function get(formId) {
 
 /**
  * Create a document in the database
- * @param {FormMetadataDocument} form - form configuration
+ * @param {FormMetadataDocument} document - form metadata document
  */
-export async function create(form) {
+export async function create(document) {
   const coll = /** @satisfies {Collection<FormMetadataDocument>} */ (
     db.collection(COLLECTION_NAME)
   )
 
   try {
-    const result = await coll.insertOne(form)
+    const result = await coll.insertOne(document)
 
     return result
   } catch (err) {
     if (err instanceof MongoServerError && err.code === 11000) {
-      throw new FormAlreadyExistsError(form.slug)
+      throw new FormAlreadyExistsError(document.slug)
     }
 
     throw err

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -5,8 +5,8 @@ import * as formTemplates from '~/src/api/forms/templates.js'
 import { formDefinitionSchema } from '~/src/models/forms.js'
 
 /**
- * Maps a document to form metadata
- * @param {WithId<FormMetadataDocument>} document - A mongo document
+ * Maps a form metadata document from MongoDB to form metadata
+ * @param {WithId<FormMetadataDocument>} document - form metadata document (with ID)
  * @returns {FormMetadata}
  */
 function mapForm(document) {
@@ -22,7 +22,7 @@ function mapForm(document) {
 
 /**
  * Adds an empty form
- * @param {FormMetadataInput} formMetadataInput - the desired form configuration to save
+ * @param {FormMetadataInput} formMetadataInput - the desired form metadata to save
  * @throws {FormAlreadyExistsError} - if the form slug already exists
  * @throws {InvalidFormDefinitionError} - if the form definition is invalid
  */
@@ -44,7 +44,7 @@ export async function createForm(formMetadataInput) {
   const slug = formTitleToSlug(title)
 
   /**
-   * Create the configuration document
+   * Create the metadata document
    * @satisfies {FormMetadataDocument}
    */
   const document = { ...formMetadataInput, slug }
@@ -59,7 +59,7 @@ export async function createForm(formMetadataInput) {
 }
 
 /**
- * Lists the available form configurations
+ * Lists the available form metadata
  */
 export async function listForms() {
   const documents = await formMetadata.list()
@@ -68,7 +68,7 @@ export async function listForms() {
 }
 
 /**
- * Retrieves a form configuration
+ * Retrieves form metadata
  * @param {string} formId - ID of the form
  */
 export async function getForm(formId) {

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * Form configuration type
+ * Form metadata type
  * @typedef {object} FormMetadata
  * @property {string} id - The id of the form
  * @property {string} slug - The human-readable slug id of the form


### PR DESCRIPTION
Follow up to https://github.com/DEFRA/forms-manager/pull/66 and https://github.com/DEFRA/forms-manager/pull/65 with a few more missed comments

I've kept a shorthand `document` and `definition` to avoid clashes (e.g. with `* as formDefinition`)