### PR TITLE
Patch form definition name from metdata

### DIFF
--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -150,7 +150,7 @@ export async function updateDraftFormDefinition(formId, definition, author) {
     }
 
     // some definition attributes shouldn't be customised by users, so patch
-    // them on every write to prevent imported forms drifting.
+    // them on every write to prevent imported forms drifting (e.g. JSON upload)
     definition.name = form.title
 
     const session = client.startSession()

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -149,6 +149,9 @@ export async function updateDraftFormDefinition(formId, definition, author) {
       throw Boom.badRequest(`Form with ID '${formId}' has no draft state`)
     }
 
+    // patch the form definition with attributes from the title, where they're not designed to be customised
+    definition.name = form.title
+
     const session = client.startSession()
 
     try {

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -149,7 +149,8 @@ export async function updateDraftFormDefinition(formId, definition, author) {
       throw Boom.badRequest(`Form with ID '${formId}' has no draft state`)
     }
 
-    // patch the form definition with attributes from the title, where they're not designed to be customised
+    // some definition attributes shouldn't be customised by users, so patch
+    // them on every write to prevent imported forms drifting.
     definition.name = form.title
 
     const session = client.startSession()

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -207,6 +207,12 @@ describe('Forms service', () => {
       await expect(getFormDefinition('123')).resolves.toMatchObject(definition)
     })
 
+    it('should update the draft form definition with required attributes upon creation', async () => {
+      await updateDraftFormDefinition('123', formDefinition, author)
+
+      expect(formDefinition.name).toBe(formMetadataDocument.title)
+    })
+
     it('should throw an error if the form associated with the definition does not exist', async () => {
       const error = Boom.notFound("Form with ID '123' not found")
 

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -208,9 +208,19 @@ describe('Forms service', () => {
     })
 
     it('should update the draft form definition with required attributes upon creation', async () => {
-      await updateDraftFormDefinition('123', formDefinition, author)
+      const formDefinitionCustomisedTitle = actualEmptyForm()
+      formDefinitionCustomisedTitle.name =
+        "A custom form name that shouldn't be allowed"
 
-      expect(formDefinition.name).toBe(formMetadataDocument.title)
+      await updateDraftFormDefinition(
+        '123',
+        formDefinitionCustomisedTitle,
+        author
+      )
+
+      expect(formDefinitionCustomisedTitle.name).toBe(
+        formMetadataDocument.title
+      )
     })
 
     it('should throw an error if the form associated with the definition does not exist', async () => {


### PR DESCRIPTION
Prevents drift with manually uploaded forms