### PR TITLE
Autodetect the start page rather than relying on possibly outdated JSON

### DIFF
--- a/src/api/forms/form-fixers.js
+++ b/src/api/forms/form-fixers.js
@@ -1,0 +1,24 @@
+/**
+ * Returns the start page for the form. Computed by counting the next paths in a form definition
+ * and returning page that doesn't have a reference, meaning it must be a start page / root node.
+ *
+ * It's possibe for forms to be malformed and have multiple start pages while they're being developed. This may be
+ * valid during development, but in this scenario we can't detect the real start page and we require
+ * the user to fix this themselves.
+ * @param {import('~/src/api/types.js').FormDefinition} formDefinition
+ */
+export function getStartPage(formDefinition) {
+  // get a unique list of all pages that are linked to by other pages
+  const pageReferences = new Set(
+    formDefinition.pages.flatMap((page) => page.next?.map((next) => next.path))
+  )
+
+  // for each page on the form, work out if it's referenced by another page
+  // those that aren't referenced must be start pages
+  const startPages = formDefinition.pages
+    .map((page) => page.path)
+    .filter((page) => !pageReferences.has(page))
+
+  // we can only set the start page if there is a single one, else the user has made an error
+  return startPages.length === 1 ? startPages[0] : formDefinition.startPage
+}

--- a/src/api/forms/form-fixers.test.js
+++ b/src/api/forms/form-fixers.test.js
@@ -1,0 +1,37 @@
+import { getStartPage } from './form-fixers.js'
+
+describe('getStartPage', () => {
+  it('should return the start page when there is only one', () => {
+    const formDefinition = /** @type {FormDefinition} */ ({
+      startPage: 'old-page',
+      pages: [
+        { path: 'page1', next: [{ path: 'page2' }] },
+        { path: 'page2', next: [{ path: 'page3' }] },
+        { path: 'page3', next: [] }
+      ]
+    })
+
+    const result = getStartPage(formDefinition)
+
+    expect(result).toBe('page1')
+  })
+
+  it('should return the start page when there are multiple start pages', () => {
+    const formDefinition = /** @type {FormDefinition} */ ({
+      startPage: 'my-original-start-page',
+      pages: [
+        { path: 'page1', next: [{ path: 'page3' }] },
+        { path: 'page2', next: [{ path: 'page3' }] },
+        { path: 'page3', next: [] }
+      ]
+    })
+
+    const result = getStartPage(formDefinition)
+
+    expect(result).toBe('my-original-start-page')
+  })
+})
+
+/**
+ * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
+ */

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -150,7 +150,7 @@ export async function updateDraftFormDefinition(formId, definition, author) {
     }
 
     // some definition attributes shouldn't be customised by users, so patch
-    // them on every write to prevent imported forms drifting.
+    // them on every write to prevent imported forms drifting (e.g. JSON upload)
     definition.name = form.title
 
     const session = client.startSession()

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -149,6 +149,9 @@ export async function updateDraftFormDefinition(formId, definition, author) {
       throw Boom.badRequest(`Form with ID '${formId}' has no draft state`)
     }
 
+    // patch the form definition with attributes from the title, where they're not designed to be customised
+    definition.name = form.title
+
     const session = client.startSession()
 
     try {

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -149,7 +149,8 @@ export async function updateDraftFormDefinition(formId, definition, author) {
       throw Boom.badRequest(`Form with ID '${formId}' has no draft state`)
     }
 
-    // patch the form definition with attributes from the title, where they're not designed to be customised
+    // some definition attributes shouldn't be customised by users, so patch
+    // them on every write to prevent imported forms drifting.
     definition.name = form.title
 
     const session = client.startSession()

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -207,6 +207,12 @@ describe('Forms service', () => {
       await expect(getFormDefinition('123')).resolves.toMatchObject(definition)
     })
 
+    it('should update the draft form definition with required attributes upon creation', async () => {
+      await updateDraftFormDefinition('123', formDefinition, author)
+
+      expect(formDefinition.name).toBe(formMetadataDocument.title)
+    })
+
     it('should throw an error if the form associated with the definition does not exist', async () => {
       const error = Boom.notFound("Form with ID '123' not found")
 

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -208,9 +208,19 @@ describe('Forms service', () => {
     })
 
     it('should update the draft form definition with required attributes upon creation', async () => {
-      await updateDraftFormDefinition('123', formDefinition, author)
+      const formDefinitionCustomisedTitle = actualEmptyForm()
+      formDefinitionCustomisedTitle.name =
+        "A custom form name that shouldn't be allowed"
 
-      expect(formDefinition.name).toBe(formMetadataDocument.title)
+      await updateDraftFormDefinition(
+        '123',
+        formDefinitionCustomisedTitle,
+        author
+      )
+
+      expect(formDefinitionCustomisedTitle.name).toBe(
+        formMetadataDocument.title
+      )
     })
 
     it('should throw an error if the form associated with the definition does not exist', async () => {

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -223,6 +223,12 @@ describe('Forms service', () => {
       )
     })
 
+    it('should update the draft form definition with required attributes upon creation', async () => {
+      await updateDraftFormDefinition('123', formDefinition, author)
+
+      expect(formDefinition.name).toBe(formMetadataDocument.title)
+    })
+
     it('should throw an error if the form associated with the definition does not exist', async () => {
       const error = Boom.notFound("Form with ID '123' not found")
 

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -7,6 +7,7 @@ import {
   InvalidFormDefinitionError
 } from '~/src/api/forms/errors.js'
 import * as formDefinition from '~/src/api/forms/form-definition-repository.js'
+import { getStartPage } from '~/src/api/forms/form-fixers.js'
 import * as formMetadata from '~/src/api/forms/form-metadata-repository.js'
 import {
   createForm,
@@ -49,6 +50,7 @@ jest.mock('~/src/mongo.js', () => {
     }
   }
 })
+jest.mock('~/src/api/forms/form-fixers.js')
 
 const { empty: actualEmptyForm } = /** @type {typeof formTemplates} */ (
   jest.requireActual('~/src/api/forms/templates.js')
@@ -208,6 +210,8 @@ describe('Forms service', () => {
     })
 
     it('should update the draft form definition with required attributes upon creation', async () => {
+      jest.mocked(getStartPage).mockReturnValueOnce('/page-one')
+
       const formDefinitionCustomisedTitle = actualEmptyForm()
       formDefinitionCustomisedTitle.name =
         "A custom form name that shouldn't be allowed"
@@ -221,12 +225,8 @@ describe('Forms service', () => {
       expect(formDefinitionCustomisedTitle.name).toBe(
         formMetadataDocument.title
       )
-    })
 
-    it('should update the draft form definition with required attributes upon creation', async () => {
-      await updateDraftFormDefinition('123', formDefinition, author)
-
-      expect(formDefinition.name).toBe(formMetadataDocument.title)
+      expect(formDefinitionCustomisedTitle.startPage).toBe('/page-one')
     })
 
     it('should throw an error if the form associated with the definition does not exist', async () => {

--- a/src/api/forms/templates.js
+++ b/src/api/forms/templates.js
@@ -6,7 +6,7 @@ import { ComponentType } from '@defra/forms-model'
 export function empty() {
   return /** @satisfies {FormDefinition} */ ({
     name: '',
-    startPage: '/page-one',
+    startPage: '/random-page',
     pages: [
       {
         path: '/page-one',


### PR DESCRIPTION
Previously, when we renamed a start page in the form editor, the `startPage` would be updated too. ~We've removed this, so we need an alternative way of setting the `startPage`.~

The original method was flawed anyway, as it only handled page renames, but it didn't account for users who create entirely new start pages. Imagine I have an existing branch on a form (with a start page), but I create a new branch with a new start page and then delete my old branch, the start page never have been updated.

As an example, deleting the original "First page" and replacing it with "new start page":

![image](https://github.com/DEFRA/forms-manager/assets/6862563/013448cb-7ec4-4fb4-b3da-69641b2af045)

This way, when a user saves a form, the start page is automatically detected. It supports all scenarios, e.g.:

- Fixes: Manually updating the JSON and putting in an incorrect `startPage` entry
- Fixes: Changing the start page, leaving the old `startPage` in place
- Fixes: Renaming the start page

Longer term we might want to add UI functionality for the start page to be set. Or better yet, keep the autodetection but add some proper error handling in place to guide the users to fix their mistakes (a form can't have multiple start pages).