### PR TITLE
Remove Docker compose `version` (obsolete)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
   mongo:
     # Initialise a Mongo cluster with a replicaset of 1 node.


### PR DESCRIPTION
See: https://docs.docker.com/compose/compose-file/04-version-and-name/

Without this change, Docker prevents startup

```console
WARN[0000] /Users/colin/Sites/Defra/forms-manager/docker-compose.yml: `version` is obsolete
request returned Internal Server Error for API route and version http://%2FUsers%2Fcolin%2F.docker%2Frun%2Fdocker.sock/v1.45/containers/json?all=1&filters=%7B%22label%22%3A%7B%22com.docker.compose.config-hash%22%3Atrue%2C%22com.docker.compose.project%3Dforms-manager%22%3Atrue%7D%7D, check if the server supports the requested API version
```