### PR TITLE
Prevent docker services from restarting when stopped

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     # the replicaset nodes. For local development this is overkill, so just turn off auth and connect to Mongo without creds.
     image: mongo:6.0
     command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
-    restart: always
+    restart: unless-stopped
     ports:
       - 27017:27017
     healthcheck:
@@ -25,7 +25,7 @@ services:
 
   mongo-express:
     image: mongo-express
-    restart: always
+    restart: unless-stopped
     ports:
       - 8081:8081
     environment:


### PR DESCRIPTION
This PR prevents our Docker services restarting automatically (e.g. after a reboot)

When following the README you'll currently see `docker compose up` reconnects rather than starts

```patch
-   restart: always
+   restart: unless-stopped
```

>Similar to `always`, except that when the container is stopped (manually or otherwise), it isn't restarted even after Docker daemon restarts.