### PR TITLE
Reject forms with missing required attributes when going live

### DIFF
--- a/src/api/forms/constants.js
+++ b/src/api/forms/constants.js
@@ -1,0 +1,7 @@
+export const makeFormLiveErrorMessages = {
+  missingDraft: 'This form is not in draft, so it cannot be published as live.',
+  missingStartPage:
+    'This form has no start page. Please ensure there is only one starting page in the draft form.',
+  missingOutputEmail:
+    'This form has no output email address configured, therefore submissions wil not be sent anywhere. Please add an output email to the draft form.'
+}

--- a/src/api/forms/constants.js
+++ b/src/api/forms/constants.js
@@ -1,7 +1,8 @@
 export const makeFormLiveErrorMessages = {
-  missingDraft: 'This form is not in draft, so it cannot be published as live.',
+  missingDraft:
+    'This form is already live. Create a new draft to change the form.',
   missingStartPage:
-    'This form has no start page. Please ensure there is only one starting page in the draft form.',
+    'The questions in this form are not all connected. Connect all pages within the form.',
   missingOutputEmail:
-    'This form has no output email address configured, therefore submissions wil not be sent anywhere. Please add an output email to the draft form.'
+    'The draft form does not contain an output email address. Add an output email address for forms to be sent to.'
 }

--- a/src/api/forms/errors.js
+++ b/src/api/forms/errors.js
@@ -31,21 +31,6 @@ export class InvalidFormDefinitionError extends ApplicationError {
 }
 
 /**
- * Indicates the form metadata and/or definition could not be persisted.
- */
-export class FormOperationFailedError extends ApplicationError {
-  name = 'FailedCreationOperationError'
-
-  /**
-   * Constructs an error
-   * @param {ErrorOptions} [options]
-   */
-  constructor(options) {
-    super('Failed to persist the form metadata and/or definition.', options)
-  }
-}
-
-/**
  * Indicates the form already exists so cannot be created again.
  */
 export class FormAlreadyExistsError extends ApplicationError {

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -205,7 +205,7 @@ export async function createLiveFromDraft(formId, author) {
       )
 
       throw Boom.badRequest(
-        `This form has no draft state, so it cannot be deployed to live.`
+        `This form is not in draft, so it cannot be published as live.`
       )
     }
 
@@ -213,7 +213,7 @@ export async function createLiveFromDraft(formId, author) {
 
     if (!draftFormDefinition?.startPage) {
       throw Boom.badRequest(
-        `This form has no start page defined. Please ensure there is only one starting page in the draft form.`
+        `This form has no start page. Please ensure there is only one starting page in the draft form.`
       )
     }
 

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -209,7 +209,21 @@ export async function createLiveFromDraft(formId, author) {
     const form = await getForm(formId)
 
     if (!form.draft) {
-      throw Boom.badRequest(`Form with ID '${formId}' has no draft state`)
+      logger.error(
+        `Form with ID '${formId}' has no draft state so failed deployment to live`
+      )
+
+      throw Boom.badRequest(
+        `This form has no draft state, so it cannot be deployed to live.`
+      )
+    }
+
+    const draftFormDefinition = await formDefinition.get(formId, 'draft')
+
+    if (!draftFormDefinition?.startPage) {
+      throw Boom.badRequest(
+        `This form has no start page defined. Please ensure there is only one starting page in the draft form.`
+      )
     }
 
     // Build the live state
@@ -264,7 +278,7 @@ export async function createLiveFromDraft(formId, author) {
       throw Boom.internal(error)
     }
 
-    throw error
+    throw cause
   }
 }
 

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -1,6 +1,8 @@
 import { formDefinitionSchema, slugify } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
+import { makeFormLiveErrorMessages } from './constants.js'
+
 import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/repositories/form-metadata-repository.js'
@@ -204,17 +206,17 @@ export async function createLiveFromDraft(formId, author) {
         `Form with ID '${formId}' has no draft state so failed deployment to live`
       )
 
-      throw Boom.badRequest(
-        `This form is not in draft, so it cannot be published as live.`
-      )
+      throw Boom.badRequest(makeFormLiveErrorMessages.missingDraft)
     }
 
     const draftFormDefinition = await formDefinition.get(formId, 'draft')
 
     if (!draftFormDefinition?.startPage) {
-      throw Boom.badRequest(
-        `This form has no start page. Please ensure there is only one starting page in the draft form.`
-      )
+      throw Boom.badRequest(makeFormLiveErrorMessages.missingStartPage)
+    }
+
+    if (!draftFormDefinition.outputEmail) {
+      throw Boom.badRequest(makeFormLiveErrorMessages.missingOutputEmail)
     }
 
     // Build the live state

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -1,10 +1,7 @@
 import { formDefinitionSchema, slugify } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
-import {
-  FormOperationFailedError,
-  InvalidFormDefinitionError
-} from '~/src/api/forms/errors.js'
+import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/repositories/form-metadata-repository.js'
 import * as formTemplates from '~/src/api/forms/templates.js'
@@ -180,19 +177,13 @@ export async function updateDraftFormDefinition(formId, definition, author) {
     }
 
     logger.info(`Updated form metadata (draft) for form ID ${formId}`)
-  } catch (cause) {
-    const error = new FormOperationFailedError({ cause })
-
+  } catch (err) {
     logger.error(
-      error,
+      err,
       `Updating form definition (draft) for form ID ${formId} failed`
     )
 
-    if (!Boom.isBoom(cause)) {
-      throw Boom.internal(error)
-    }
-
-    throw error
+    throw err
   }
 }
 
@@ -269,16 +260,10 @@ export async function createLiveFromDraft(formId, author) {
 
     logger.info(`Removed form metadata (draft) for form ID ${formId}`)
     logger.info(`Made draft live for form ID ${formId}`)
-  } catch (cause) {
-    const error = new FormOperationFailedError({ cause })
+  } catch (err) {
+    logger.error(err, `Make draft live for form ID ${formId} failed`)
 
-    logger.error(error, `Make draft live for form ID ${formId} failed`)
-
-    if (!Boom.isBoom(cause)) {
-      throw Boom.internal(error)
-    }
-
-    throw cause
+    throw err
   }
 }
 
@@ -327,16 +312,10 @@ export async function createDraftFromLive(formId, author) {
 
     logger.info(`Added form metadata (draft) for form ID ${formId}`)
     logger.info(`Created draft to edit for form ID ${formId}`)
-  } catch (cause) {
-    const error = new FormOperationFailedError({ cause })
+  } catch (err) {
+    logger.error(err, `Create draft to edit for form ID ${formId} failed`)
 
-    logger.error(error, `Create draft to edit for form ID ${formId} failed`)
-
-    if (!Boom.isBoom(error)) {
-      throw Boom.internal(error)
-    }
-
-    throw error
+    throw err
   }
 }
 

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -157,7 +157,24 @@ describe('Forms service', () => {
     })
 
     test('should create a live state from existing draft form', async () => {
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(definition)
       await expect(createLiveFromDraft(id, author)).resolves.toBeUndefined()
+    })
+
+    test('should fail to create a live state from existing draft form when no start page', async () => {
+      const draftDefinitionNoStartPage =
+        /** @type {import('@defra/forms-model').FormDefinition} */ (definition)
+      delete draftDefinitionNoStartPage.startPage
+
+      jest
+        .mocked(formDefinition.get)
+        .mockResolvedValueOnce(draftDefinitionNoStartPage)
+
+      await expect(createLiveFromDraft(id, author)).rejects.toThrow(
+        Boom.badRequest(
+          'This form has no start page defined. Please ensure there is only one starting page in the draft form.'
+        )
+      )
     })
   })
 

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -2,10 +2,7 @@ import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 import { pino } from 'pino'
 
-import {
-  FormOperationFailedError,
-  InvalidFormDefinitionError
-} from '~/src/api/forms/errors.js'
+import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/repositories/form-metadata-repository.js'
 import {
@@ -280,7 +277,7 @@ describe('Forms service', () => {
 
       await expect(
         updateDraftFormDefinition('123', definition, author)
-      ).rejects.toThrow(new FormOperationFailedError({ cause: error }))
+      ).rejects.toThrow(error)
     })
   })
 

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -169,7 +169,7 @@ describe('Forms service', () => {
 
       await expect(createLiveFromDraft(id, author)).rejects.toThrow(
         Boom.badRequest(
-          'This form has no start page defined. Please ensure there is only one starting page in the draft form.'
+          'This form has no start page. Please ensure there is only one starting page in the draft form.'
         )
       )
     })

--- a/src/api/forms/templates.js
+++ b/src/api/forms/templates.js
@@ -7,6 +7,7 @@ export function empty() {
   return /** @satisfies {FormDefinition} */ ({
     name: '',
     startPage: '/page-one',
+    outputEmail: 'test@defra.gov.uk',
     pages: [
       {
         path: '/page-one',


### PR DESCRIPTION
Ticket: https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/401610

Rejects forms when promoting to live if they don't contain start pages
Removes the unneccessary `FormOperationFailedError` layer, it doesn't add any value