### PR TITLE
401088 Track updates when a draft is created

### DIFF
--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -405,7 +405,9 @@ export async function createDraftFromLive(formId, author) {
         updatedBy: author,
         createdAt: now,
         createdBy: author
-      }
+      },
+      updatedAt: now,
+      updatedBy: author
     }
 
     const session = client.startSession()


### PR DESCRIPTION
Extends the work done in https://github.com/DEFRA/forms-manager/pull/230 to account for draft forms being created from live.