### PR TITLE
Switch logging from preferred_username to oid

### DIFF
--- a/src/plugins/auth/index.js
+++ b/src/plugins/auth/index.js
@@ -43,29 +43,31 @@ export const auth = {
             }
           }
 
-          const { preferred_username: preferredUsername, groups = [] } = user
+          const { oid, groups = [] } = user
 
-          if (!preferredUsername) {
-            logger.error('Authentication error: Missing preferred_username')
-            return {
-              isValid: false
-            }
-          }
-
-          logger.debug(
-            `User ${preferredUsername}: validating against groups: ${groups.length ? groups.join(', ') : '[]'}`
-          )
-
-          if (!groups.includes(roleEditorGroupId)) {
-            logger.warn(
-              `User ${preferredUsername}: failed authorisation. "${roleEditorGroupId}" not in groups`
+          if (!oid || typeof oid !== 'string') {
+            logger.error(
+              'Authentication error: user.oid is not a string or is missing'
             )
             return {
               isValid: false
             }
           }
 
-          logger.debug(`User ${preferredUsername}: passed authorisation`)
+          logger.debug(
+            `User ${oid}: validating against groups: ${groups.length ? groups.join(', ') : '[]'}`
+          )
+
+          if (!groups.includes(roleEditorGroupId)) {
+            logger.warn(
+              `User ${oid}: failed authorisation. "${roleEditorGroupId}" not in groups`
+            )
+            return {
+              isValid: false
+            }
+          }
+
+          logger.debug(`User ${oid}: passed authorisation`)
           return {
             isValid: true,
             credentials: { user }
@@ -81,6 +83,5 @@ export const auth = {
 
 /**
  * @import { ServerRegisterPluginObject } from '@hapi/hapi'
- * @import { HapiJwt } from '@hapi/jwt'
  * @import { Artifacts, UserProfile } from '~/src/plugins/auth/types.js'
  */

--- a/src/plugins/log-requests.js
+++ b/src/plugins/log-requests.js
@@ -19,11 +19,8 @@ export const logRequests = {
       if (isAuthenticated && credentials.user) {
         const { user } = credentials
 
-        if (
-          'preferred_username' in user &&
-          typeof user.preferred_username === 'string'
-        ) {
-          userPrefix = ` [${user.preferred_username}] `
+        if ('oid' in user && typeof user.oid === 'string') {
+          userPrefix = ` [${user.oid}] `
         }
       }
 

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -30,14 +30,14 @@ import {
  * @returns {FormMetadataAuthor}
  */
 function getAuthor(user) {
-  if (!user || !user.sub) {
+  if (!user || !('oid' in user && typeof user.oid === 'string')) {
     throw Boom.unauthorized(
-      'Failed to get the author, user is undefined or has no id (sub)'
+      'Failed to get the author, user is undefined or has a malformed/missing oid'
     )
   }
 
   return {
-    id: user.sub,
+    id: user.oid,
     displayName: `${user.given_name} ${user.family_name}`
   }
 }

--- a/test/fixtures/auth.js
+++ b/test/fixtures/auth.js
@@ -9,7 +9,8 @@ export const auth = {
       groups: ['7049296f-2156-4d61-8ac3-349276438ef9'],
       name: 'Enrique Chase (Defra)',
       scp: 'forms.user',
-      sub: 'hgtL_1p2Me5JkBB6JeB20PyU3YDuP9PjEZwi7m1QGng'
+      sub: 'hgtL_1p2Me5JkBB6JeB20PyU3YDuP9PjEZwi7m1QGng',
+      oid: '86758ba9-92e7-4287-9751-7705e449688e'
     }
   }
 }


### PR DESCRIPTION
- Drops preferred_username in the logs and instead uses oid as it's classed as non-PII in the log ingestion pipeline
- Stores `oid` as the user ID in audit records, so it can be looked up in Azure AD