### PR TITLE
Add support for notification email from metadata

### DIFF
--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -50,6 +50,7 @@ function mapForm(document) {
     contact: document.contact,
     submissionGuidance: document.submissionGuidance,
     privacyNoticeUrl: document.privacyNoticeUrl,
+    notificationEmail: document.notificationEmail,
     draft: document.draft,
     live: document.live,
     createdBy: created.createdBy,
@@ -340,7 +341,8 @@ export async function createLiveFromDraft(formId, author) {
       throw Boom.badRequest(makeFormLiveErrorMessages.missingStartPage)
     }
 
-    if (!draftFormDefinition.outputEmail) {
+    if (!draftFormDefinition.outputEmail && !form.notificationEmail) {
+      // TODO: remove the form def check once all forms have a notification email
       throw Boom.badRequest(makeFormLiveErrorMessages.missingOutputEmail)
     }
 

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -82,7 +82,8 @@ describe('Forms service', () => {
       phone: '0800 000 1234'
     },
     submissionGuidance: 'We’ll send you an email to let you know the outcome.',
-    privacyNoticeUrl: 'https://www.gov.uk/help/privacy-notice'
+    privacyNoticeUrl: 'https://www.gov.uk/help/privacy-notice',
+    notificationEmail: 'defraforms@defra.gov.uk'
   }
 
   /**
@@ -277,14 +278,23 @@ describe('Forms service', () => {
     })
 
     test('should fail to create a live state from existing draft form when there is no output email', async () => {
-      const draftDefinitionNoStartPage = /** @type {FormDefinition} */ (
+      const draftDefinitionNoOutputEmail = /** @type {FormDefinition} */ (
         definition
       )
-      delete draftDefinitionNoStartPage.outputEmail
+      delete draftDefinitionNoOutputEmail.outputEmail
+
+      const metadataNoNotificationEmail = {
+        .../** @type {WithId<FormMetadataDocument>} */ (formMetadataDocument)
+      }
+      delete metadataNoNotificationEmail.notificationEmail
 
       jest
         .mocked(formDefinition.get)
-        .mockResolvedValueOnce(draftDefinitionNoStartPage)
+        .mockResolvedValue(draftDefinitionNoOutputEmail)
+
+      jest
+        .mocked(formMetadata.get)
+        .mockResolvedValueOnce(metadataNoNotificationEmail)
 
       await expect(createLiveFromDraft(id, author)).rejects.toThrow(
         Boom.badRequest(makeFormLiveErrorMessages.missingOutputEmail)


### PR DESCRIPTION
This replicates Dave's current approach for editing metadata items. It adds the notification email output to the form metadata.

I am not yet removing the output email from the form defininition. I will do that as a follow-up.

Supports https://github.com/DEFRA/forms-designer/pull/481.