### PR TITLE
Skip Docker publish unless source or configs change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
 
+    paths:
+      - '.browserslistrc'
+      - 'babel.config.*'
+      - 'Dockerfile'
+      - 'src/**'
+      - '!**/*.test.*'
+
 concurrency:
   group: publish
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+concurrency:
+  group: publish
+
 permissions:
   id-token: write
   contents: write


### PR DESCRIPTION
This PR prevents concurrent publishing and only runs when source files or configs change:

```patch
on:
  push:
    branches:
      - main
+   paths:
+     - '.browserslistrc'
+     - 'babel.config.*'
+     - 'Dockerfile'
+     - 'src/**'
+     - '!**/*.test.*'
```