### PR TITLE
Feature 479043: Sorting on GET /forms endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/forms-model": "^3.0.387",
+        "@defra/forms-model": "^3.0.389",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.3.12",
         "@hapi/jwt": "^3.2.0",
@@ -1735,9 +1735,9 @@
       "dev": true
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.387",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.387.tgz",
-      "integrity": "sha512-bUrrm/b+JgGOd6DkVP06hOu7KVrNtMNwBdBLIePprqClW+W/SaSmIyL6I6mYmwmDRB4dG513qDRlpdAlfvdj4w==",
+      "version": "3.0.389",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.389.tgz",
+      "integrity": "sha512-sPF+1ytmbV6bFiNX/TW8xODEMkrVtewMT5bGusbQ/SiJfBAM4rnPDTvezvXb0d8lzqj5+hAX2AFjLHIPaMK9Yw==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "marked": "^15.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "dependencies": {
-    "@defra/forms-model": "^3.0.387",
+    "@defra/forms-model": "^3.0.389",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.3.12",
     "@hapi/jwt": "^3.2.0",

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -164,27 +164,26 @@ export async function createForm(metadataInput, author) {
 }
 
 /**
- * Lists forms and returns query result metadata (e.g., pagination details, total counts)
- * @param {PaginationOptions} [options] - Optional pagination options
- * @returns {Promise<FormMetadata[] | QueryResult<FormMetadata>>}
+ * Lists forms and returns query result metadata (e.g., pagination and sort details)
+ * @param {QueryOptions} options - Pagination and sorting options
+ * @returns {Promise<QueryResult<FormMetadata>>}
  */
 export async function listForms(options) {
-  let documents
-
-  if (!options?.page && !options?.perPage) {
-    documents = await formMetadata.listAll()
-    return documents.map(mapForm)
-  }
-
-  const page = options.page ?? 1
-  const perPage = options.perPage ?? MAX_RESULTS
+  const {
+    page = 1,
+    perPage = MAX_RESULTS,
+    sortBy = 'updatedAt',
+    order = 'desc'
+  } = options
 
   const { documents: pagedDocuments, totalItems } = await formMetadata.list({
     page,
-    perPage
+    perPage,
+    sortBy,
+    order
   })
-  documents = pagedDocuments
-  const forms = documents.map(mapForm)
+
+  const forms = pagedDocuments.map(mapForm)
 
   return {
     data: forms,
@@ -194,6 +193,10 @@ export async function listForms(options) {
         perPage,
         totalItems,
         totalPages: Math.ceil(totalItems / perPage)
+      },
+      sorting: {
+        sortBy,
+        order
       }
     }
   }
@@ -540,7 +543,7 @@ export async function removeForm(formId, force = false) {
 }
 
 /**
- * @import { FormDefinition, FormMetadata, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, QueryResult, PaginationOptions } from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, FormMetadata, QueryResult, QueryOptions } from '@defra/forms-model'
  * @import { WithId } from 'mongodb'
  * @import { PartialFormMetadataDocument} from '~/src/api/types.js'
  */

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -6,7 +6,7 @@
  * @typedef {Request<{ Server: { db: Db }, Payload: FormMetadataInput }>} RequestFormMetadataCreate
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: { force: boolean }}>} RequestRemoveFormById
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: Partial<FormMetadataInput> }>} RequestFormMetadataUpdateById
- * @typedef {Request<{ Server: { db: Db }, Query: PaginationOptions }>} RequestListForms
+ * @typedef {Request<{ Server: { db: Db }, Query: QueryOptions }>} RequestListForms
  */
 
 /**
@@ -14,7 +14,7 @@
  */
 
 /**
- * @import { FormByIdInput, FormBySlugInput, FormDefinition, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, PaginationOptions } from '@defra/forms-model'
+ * @import { FormByIdInput, FormBySlugInput, FormDefinition, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, QueryOptions } from '@defra/forms-model'
  * @import { Request } from '@hapi/hapi'
  * @import { Db } from 'mongodb'
  */

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -1,7 +1,7 @@
 import {
   formMetadataInputKeys,
   formMetadataInputSchema,
-  paginationOptionsSchema
+  queryOptionsSchema
 } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
@@ -60,7 +60,7 @@ export default [
     options: {
       auth: false,
       validate: {
-        query: paginationOptionsSchema
+        query: queryOptionsSchema
       }
     }
   },

--- a/src/routes/forms.test.js
+++ b/src/routes/forms.test.js
@@ -93,8 +93,22 @@ describe('Forms route', () => {
   const slug = stubFormMetadataOutput.slug
 
   describe('Success responses', () => {
-    test('Testing GET /forms route returns empty array when no pagination is used', async () => {
-      jest.mocked(listForms).mockResolvedValue([])
+    test('GET /forms returns empty data array with default pagination and sorting when no parameters are used', async () => {
+      jest.mocked(listForms).mockResolvedValue({
+        data: [],
+        meta: {
+          pagination: {
+            page: 1,
+            perPage: 10,
+            totalItems: 0,
+            totalPages: 1
+          },
+          sorting: {
+            sortBy: 'updatedAt',
+            order: 'desc'
+          }
+        }
+      })
 
       const response = await server.inject({
         method: 'GET',
@@ -105,42 +119,24 @@ describe('Forms route', () => {
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
 
-      expect(Array.isArray(response.result)).toBe(true)
-      expect(response.result).toEqual([])
-    })
-
-    test('Testing GET /forms route without auth returns empty array when no pagination is used', async () => {
-      jest.mocked(listForms).mockResolvedValue([])
-
-      const response = await server.inject({
-        method: 'GET',
-        url: '/forms'
+      expect(response.result).toEqual({
+        data: [],
+        meta: {
+          pagination: {
+            page: 1,
+            perPage: 10,
+            totalItems: 0,
+            totalPages: 1
+          },
+          sorting: {
+            sortBy: 'updatedAt',
+            order: 'desc'
+          }
+        }
       })
-
-      expect(response.statusCode).toEqual(okStatusCode)
-      expect(response.headers['content-type']).toContain(jsonContentType)
-
-      expect(Array.isArray(response.result)).toBe(true)
-      expect(response.result).toEqual([])
     })
 
-    test('Testing GET /forms route returns a list of forms when no pagination is used', async () => {
-      jest.mocked(listForms).mockResolvedValue([stubFormMetadataOutput])
-
-      const response = await server.inject({
-        method: 'GET',
-        url: '/forms',
-        auth
-      })
-
-      expect(response.statusCode).toEqual(okStatusCode)
-      expect(response.headers['content-type']).toContain(jsonContentType)
-
-      expect(Array.isArray(response.result)).toBe(true)
-      expect(response.result).toEqual([stubFormMetadataOutput])
-    })
-
-    test('Testing GET /forms route with pagination returns paginated result', async () => {
+    test('GET /forms with sorting parameters returns sorted data and correct meta', async () => {
       jest.mocked(listForms).mockResolvedValue({
         data: [stubFormMetadataOutput],
         meta: {
@@ -149,6 +145,96 @@ describe('Forms route', () => {
             perPage: 10,
             totalItems: 1,
             totalPages: 1
+          },
+          sorting: {
+            sortBy: 'title',
+            order: 'asc'
+          }
+        }
+      })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/forms?sortBy=title&order=asc',
+        auth
+      })
+
+      expect(response.statusCode).toEqual(okStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+
+      expect(response.result).toEqual({
+        data: [stubFormMetadataOutput],
+        meta: {
+          pagination: {
+            page: 1,
+            perPage: 10,
+            totalItems: 1,
+            totalPages: 1
+          },
+          sorting: {
+            sortBy: 'title',
+            order: 'asc'
+          }
+        }
+      })
+    })
+
+    test('GET /forms with pagination and sorting parameters returns sorted paginated data', async () => {
+      jest.mocked(listForms).mockResolvedValue({
+        data: [stubFormMetadataOutput],
+        meta: {
+          pagination: {
+            page: 1,
+            perPage: 5,
+            totalItems: 1,
+            totalPages: 1
+          },
+          sorting: {
+            sortBy: 'title',
+            order: 'asc'
+          }
+        }
+      })
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/forms?page=1&perPage=5&sortBy=title&order=asc',
+        auth
+      })
+
+      expect(response.statusCode).toEqual(okStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+
+      expect(response.result).toEqual({
+        data: [stubFormMetadataOutput],
+        meta: {
+          pagination: {
+            page: 1,
+            perPage: 5,
+            totalItems: 1,
+            totalPages: 1
+          },
+          sorting: {
+            sortBy: 'title',
+            order: 'asc'
+          }
+        }
+      })
+    })
+
+    test('GET /forms with pagination parameters returns paginated data and default sorting', async () => {
+      jest.mocked(listForms).mockResolvedValue({
+        data: [stubFormMetadataOutput],
+        meta: {
+          pagination: {
+            page: 1,
+            perPage: 10,
+            totalItems: 1,
+            totalPages: 1
+          },
+          sorting: {
+            sortBy: 'updatedAt',
+            order: 'desc'
           }
         }
       })
@@ -162,7 +248,6 @@ describe('Forms route', () => {
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
 
-      expect(Array.isArray(response.result)).toBe(false)
       expect(response.result).toEqual({
         data: [stubFormMetadataOutput],
         meta: {
@@ -171,12 +256,16 @@ describe('Forms route', () => {
             perPage: 10,
             totalItems: 1,
             totalPages: 1
+          },
+          sorting: {
+            sortBy: 'updatedAt',
+            order: 'desc'
           }
         }
       })
     })
 
-    test('Testing GET /forms route with pagination returns empty paginated result', async () => {
+    test('GET /forms with pagination parameters returns empty data array and default sorting when no forms are available', async () => {
       jest.mocked(listForms).mockResolvedValue({
         data: [],
         meta: {
@@ -185,6 +274,10 @@ describe('Forms route', () => {
             perPage: 10,
             totalItems: 1,
             totalPages: 1
+          },
+          sorting: {
+            sortBy: 'updatedAt',
+            order: 'desc'
           }
         }
       })
@@ -198,7 +291,6 @@ describe('Forms route', () => {
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
 
-      expect(Array.isArray(response.result)).toBe(false)
       expect(response.result).toEqual({
         data: [],
         meta: {
@@ -207,6 +299,10 @@ describe('Forms route', () => {
             perPage: 10,
             totalItems: 1,
             totalPages: 1
+          },
+          sorting: {
+            sortBy: 'updatedAt',
+            order: 'desc'
           }
         }
       })
@@ -774,6 +870,64 @@ describe('Forms route', () => {
       expect(response.result).toMatchObject({
         error: 'Internal Server Error',
         message: 'An internal server error occurred'
+      })
+    })
+
+    test('Testing GET /forms route with invalid sorting field returns validation error', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/forms?sortBy=unknownField',
+        auth
+      })
+
+      expect(response.statusCode).toEqual(badRequestStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      expect(response.result).toMatchObject({
+        error: 'Bad Request',
+        message: '"sortBy" must be one of [updatedAt, title]',
+        validation: {
+          keys: ['sortBy'],
+          source: 'query'
+        }
+      })
+    })
+
+    test('Testing GET /forms route with invalid order value returns validation error', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/forms?order=ascending',
+        auth
+      })
+
+      expect(response.statusCode).toEqual(badRequestStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      expect(response.result).toMatchObject({
+        error: 'Bad Request',
+        message: '"order" must be one of [asc, desc]',
+        validation: {
+          keys: ['order'],
+          source: 'query'
+        }
+      })
+    })
+
+    test('Testing GET /forms route with sorting and invalid pagination parameters returns validation error', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/forms?page=-1&perPage=0&sortBy=title&order=asc',
+        auth
+      })
+
+      expect(response.statusCode).toEqual(badRequestStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      expect(response.result).toMatchObject({
+        error: 'Bad Request',
+        message:
+          '"page" must be a positive number. "page" must be greater than or equal to 1. "perPage" must be a positive number. "perPage" must be greater than or equal to 1',
+        validation: {
+          keys: ['page', 'page', 'perPage', 'perPage'],
+          source: 'query'
+        }
       })
     })
   })


### PR DESCRIPTION
## Story Link
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/479043

## Description
This PR introduces sorting on the `GET /forms` endpoint. It allows sorting with `sortBy` with a value of either  `updatedAt` or `title`, both `asc` or `desc` and defaults to `updatedAt` with `desc` (most recent forms`.
In terms of the title sort, it takes into consideration the entire form title as outlined in the story.

Example meta response without sorting: 
```
{
    "data": [
    {
     ....forms
     },
    ...
    ],
    "meta": {
        "pagination": {
            "page": 1,
            "perPage": 24,
            "totalItems": 6,
            "totalPages": 1
        },
        "sorting": {
            "sortBy": "updatedAt",
            "order": "desc"
        }
    }
}
```