### PR TITLE
Feature(NO-TICKET): Add queryHandler plugin for standardised list responses with pagination, sorting and search

### DIFF
--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -6,7 +6,6 @@ import { makeFormLiveErrorMessages } from '~/src/api/forms/constants.js'
 import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/repositories/form-metadata-repository.js'
-import { MAX_RESULTS } from '~/src/api/forms/repositories/form-metadata-repository.js'
 import * as formTemplates from '~/src/api/forms/templates.js'
 import { createLogger } from '~/src/helpers/logging/logger.js'
 import { client } from '~/src/mongo.js'
@@ -164,47 +163,14 @@ export async function createForm(metadataInput, author) {
 }
 
 /**
- * Lists forms and returns query result metadata (e.g., pagination, sorting, and filtering details)
+ * Retrieves a paginated list of forms
  * @param {QueryOptions} options - Pagination, sorting, and filtering options
- * @returns {Promise<QueryResult<FormMetadata>>}
+ * @returns {Promise<{ forms: FormMetadata[], totalItems: number }>}
  */
 export async function listForms(options) {
-  const {
-    page = 1,
-    perPage = MAX_RESULTS,
-    sortBy = 'updatedAt',
-    order = 'desc',
-    title = ''
-  } = options
-
-  const { documents: pagedDocuments, totalItems } = await formMetadata.list({
-    page,
-    perPage,
-    sortBy,
-    order,
-    title
-  })
-
-  const forms = pagedDocuments.map(mapForm)
-
-  return {
-    data: forms,
-    meta: {
-      pagination: {
-        page,
-        perPage,
-        totalItems,
-        totalPages: Math.ceil(totalItems / perPage)
-      },
-      sorting: {
-        sortBy,
-        order
-      },
-      search: {
-        title
-      }
-    }
-  }
+  const { documents, totalItems } = await formMetadata.list(options)
+  const forms = documents.map(mapForm)
+  return { forms, totalItems }
 }
 
 /**

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -755,30 +755,16 @@ describe('Forms service', () => {
 
       const result = await listForms({ page: 1, perPage: 10 })
 
-      expect(result.data).toEqual(
-        expect.arrayContaining([
+      expect(result).toEqual({
+        forms: [
           expect.objectContaining({
             updatedAt: formDate,
             updatedBy: formAuthor,
             createdAt: formDate,
             createdBy: formAuthor
           })
-        ])
-      )
-      expect(result.meta).toEqual({
-        pagination: {
-          page: 1,
-          perPage: 10,
-          totalItems: 1,
-          totalPages: 1
-        },
-        search: {
-          title: ''
-        },
-        sorting: {
-          sortBy: 'updatedAt',
-          order: 'desc'
-        }
+        ],
+        totalItems: 1
       })
     })
 
@@ -790,16 +776,17 @@ describe('Forms service', () => {
 
       const result = await listForms({ page: 1, perPage: 10 })
 
-      expect(result.data).toEqual(
-        expect.arrayContaining([
+      expect(result).toEqual({
+        forms: [
           expect.objectContaining({
             updatedAt: draftDate,
             updatedBy: draftAuthor,
             createdAt: liveDate,
             createdBy: liveAuthor
           })
-        ])
-      )
+        ],
+        totalItems: 1
+      })
     })
 
     it('should handle states when draft state info is missing', async () => {
@@ -810,16 +797,17 @@ describe('Forms service', () => {
 
       const result = await listForms({ page: 1, perPage: 10 })
 
-      expect(result.data).toEqual(
-        expect.arrayContaining([
+      expect(result).toEqual({
+        forms: [
           expect.objectContaining({
             updatedAt: liveDate,
             updatedBy: liveAuthor,
             createdAt: liveDate,
             createdBy: liveAuthor
           })
-        ])
-      )
+        ],
+        totalItems: 1
+      })
     })
 
     it('should handle states when live state info is missing', async () => {
@@ -830,16 +818,17 @@ describe('Forms service', () => {
 
       const result = await listForms({ page: 1, perPage: 10 })
 
-      expect(result.data).toEqual(
-        expect.arrayContaining([
+      expect(result).toEqual({
+        forms: [
           expect.objectContaining({
             updatedAt: draftDate,
             updatedBy: draftAuthor,
             createdAt: draftDate,
             createdBy: draftAuthor
           })
-        ])
-      )
+        ],
+        totalItems: 1
+      })
     })
 
     it('should handle states when all states are missing', async () => {
@@ -850,162 +839,21 @@ describe('Forms service', () => {
 
       const result = await listForms({ page: 1, perPage: 10 })
 
-      expect(result.data).toEqual(
-        expect.arrayContaining([
+      expect(result).toEqual({
+        forms: [
           expect.objectContaining({
             updatedAt: defaultDate,
             updatedBy: defaultAuthor,
             createdAt: defaultDate,
             createdBy: defaultAuthor
           })
-        ])
-      )
-    })
-
-    it('should throw an error if forms are malformed', async () => {
-      jest.mocked(formMetadata.list).mockResolvedValue({
-        documents: [
-          {
-            _id: new ObjectId(id)
-            // Missing required attributes
-          }
         ],
         totalItems: 1
-      })
-
-      await expect(listForms({ page: 1, perPage: 10 })).rejects.toThrow(
-        'Form is malformed in the database. Expected fields are missing.'
-      )
-    })
-
-    describe('with pagination', () => {
-      it('should return paginated results with correct pagination metadata', async () => {
-        const page = 1
-        const perPage = 2
-        const totalItems = 5
-
-        /** @type {WithId<Partial<FormMetadataDocument>>[]} */
-        const documents = [formMetadataFullDocument, formMetadataDraftDocument]
-
-        jest
-          .mocked(formMetadata.list)
-          .mockResolvedValue({ documents, totalItems })
-
-        const result = await listForms({ page, perPage })
-
-        expect(formMetadata.list).toHaveBeenCalledWith({
-          page,
-          perPage,
-          sortBy: 'updatedAt',
-          order: 'desc',
-          title: ''
-        })
-        expect(result).toEqual({
-          data: expect.any(Array),
-          meta: {
-            pagination: {
-              page,
-              perPage,
-              totalItems,
-              totalPages: Math.ceil(totalItems / perPage)
-            },
-            search: {
-              title: ''
-            },
-            sorting: {
-              sortBy: 'updatedAt',
-              order: 'desc'
-            }
-          }
-        })
-        expect(result.data).toHaveLength(documents.length)
-      })
-
-      it('should return empty data when there are no forms', async () => {
-        const page = 1
-        const perPage = 10
-        const totalItems = 0
-
-        /** @type {WithId<Partial<FormMetadataDocument>>[]} */
-        const documents = []
-
-        jest
-          .mocked(formMetadata.list)
-          .mockResolvedValue({ documents, totalItems })
-
-        const result = await listForms({ page, perPage })
-
-        expect(formMetadata.list).toHaveBeenCalledWith({
-          page,
-          perPage,
-          sortBy: 'updatedAt',
-          order: 'desc',
-          title: ''
-        })
-        expect(result).toEqual({
-          data: [],
-          meta: {
-            pagination: {
-              page,
-              perPage,
-              totalItems,
-              totalPages: 0
-            },
-            search: {
-              title: ''
-            },
-            sorting: {
-              sortBy: 'updatedAt',
-              order: 'desc'
-            }
-          }
-        })
-      })
-
-      it('should handle page numbers greater than total pages', async () => {
-        const page = 5
-        const perPage = 2
-        const totalItems = 5
-
-        /** @type {WithId<Partial<FormMetadataDocument>>[]} */
-        const documents = []
-
-        jest
-          .mocked(formMetadata.list)
-          .mockResolvedValue({ documents, totalItems })
-
-        const result = await listForms({ page, perPage })
-
-        expect(formMetadata.list).toHaveBeenCalledWith({
-          page,
-          perPage,
-          sortBy: 'updatedAt',
-          order: 'desc',
-          title: ''
-        })
-        expect(result).toEqual({
-          data: [],
-          meta: {
-            pagination: {
-              page,
-              perPage,
-              totalItems,
-              totalPages: 3
-            },
-            search: {
-              title: ''
-            },
-            sorting: {
-              sortBy: 'updatedAt',
-              order: 'desc'
-            }
-          }
-        })
       })
     })
 
     describe('with sorting', () => {
-      it('should call formMetadata.list with provided sorting parameters', async () => {
+      it('should pass sorting parameters to repository', async () => {
         const page = 1
         const perPage = 10
         const sortBy = 'title'
@@ -1023,48 +871,83 @@ describe('Forms service', () => {
           .mocked(formMetadata.list)
           .mockResolvedValue({ documents, totalItems })
 
-        const result = await listForms({ page, perPage, sortBy, order, title })
+        const options = { page, perPage, sortBy, order, title }
+        const result = await listForms(options)
+
+        expect(formMetadata.list).toHaveBeenCalledWith(options)
+        expect(result).toEqual({
+          forms: expect.any(Array),
+          totalItems
+        })
+      })
+    })
+
+    describe('with search', () => {
+      it('should pass search parameters to repository', async () => {
+        const page = 1
+        const perPage = 10
+        const title = 'a search'
+
+        jest.mocked(formMetadata.list).mockResolvedValue({
+          documents: [formMetadataFullDocument, formMetadataFullDocument],
+          totalItems: 2
+        })
+
+        const result = await listForms({ page, perPage, title })
 
         expect(formMetadata.list).toHaveBeenCalledWith({
           page,
           perPage,
-          sortBy,
-          order,
           title
         })
-
-        expect(result.data).toEqual(expect.any(Array))
-        expect(result.meta.sorting).toEqual({ sortBy, order })
-        expect(result.meta.search).toEqual({ title })
+        expect(result).toEqual({
+          forms: expect.any(Array),
+          totalItems: 2
+        })
       })
 
-      it('should use default sorting parameters when none are provided', async () => {
+      it('should return empty results when search finds no matches', async () => {
         const page = 1
         const perPage = 10
-        const totalItems = 1
+        const title = 'Defra Badger Relocation and Tea Party Planning Form'
 
-        const documents = [{ ...formMetadataFullDocument }]
+        jest.mocked(formMetadata.list).mockResolvedValue({
+          documents: [],
+          totalItems: 0
+        })
 
-        jest
-          .mocked(formMetadata.list)
-          .mockResolvedValue({ documents, totalItems })
+        const result = await listForms({ page, perPage, title })
+
+        expect(formMetadata.list).toHaveBeenCalledWith({
+          page,
+          perPage,
+          title
+        })
+        expect(result).toEqual({
+          forms: [],
+          totalItems: 0
+        })
+      })
+
+      it('should use empty string for title when no search parameter is provided', async () => {
+        const page = 1
+        const perPage = 10
+
+        jest.mocked(formMetadata.list).mockResolvedValue({
+          documents: [formMetadataFullDocument],
+          totalItems: 1
+        })
 
         const result = await listForms({ page, perPage })
 
         expect(formMetadata.list).toHaveBeenCalledWith({
           page,
-          perPage,
-          sortBy: 'updatedAt',
-          order: 'desc',
-          title: ''
+          perPage
         })
-
-        expect(result.data).toEqual(expect.any(Array))
-        expect(result.meta.sorting).toEqual({
-          sortBy: 'updatedAt',
-          order: 'desc'
+        expect(result).toEqual({
+          forms: expect.any(Array),
+          totalItems: 1
         })
-        expect(result.meta.search).toEqual({ title: '' })
       })
     })
 
@@ -1081,16 +964,18 @@ describe('Forms service', () => {
 
       expect(formMetadata.list).toHaveBeenCalledWith({
         page: defaultPage,
-        perPage: defaultPerPage,
-        sortBy: 'updatedAt',
-        order: 'desc',
-        title: ''
+        perPage: defaultPerPage
       })
-      expect(result.meta.pagination).toEqual({
-        page: defaultPage,
-        perPage: defaultPerPage,
-        totalItems: 1,
-        totalPages: 1
+      expect(result).toEqual({
+        forms: [
+          expect.objectContaining({
+            updatedAt: formDate,
+            updatedBy: formAuthor,
+            createdAt: formDate,
+            createdBy: formAuthor
+          })
+        ],
+        totalItems: 1
       })
     })
 
@@ -1107,11 +992,16 @@ describe('Forms service', () => {
         perPage: defaultPerPage
       })
 
-      expect(result.meta.pagination).toEqual({
-        page: defaultPage,
-        perPage: defaultPerPage,
-        totalItems,
-        totalPages: 2
+      expect(result).toEqual({
+        forms: [
+          expect.objectContaining({
+            updatedAt: formDate,
+            updatedBy: formAuthor,
+            createdAt: formDate,
+            createdBy: formAuthor
+          })
+        ],
+        totalItems
       })
     })
 
@@ -1126,11 +1016,9 @@ describe('Forms service', () => {
         perPage: defaultPerPage
       })
 
-      expect(result.meta.pagination).toEqual({
-        page: defaultPage,
-        perPage: defaultPerPage,
-        totalItems: 0,
-        totalPages: 0
+      expect(result).toEqual({
+        forms: [],
+        totalItems: 0
       })
     })
 
@@ -1143,130 +1031,19 @@ describe('Forms service', () => {
       const result = await listForms({ page: 1, perPage: MAX_RESULTS })
 
       expect(formMetadata.list).toHaveBeenCalledWith({
-        page: defaultPage,
-        perPage: defaultPerPage,
-        sortBy: 'updatedAt',
-        order: 'desc',
-        title: ''
+        page: 1,
+        perPage: MAX_RESULTS
       })
-      expect(result.meta.pagination).toEqual({
-        page: defaultPage,
-        perPage: defaultPerPage,
-        totalItems: 1,
-        totalPages: 1
-      })
-      expect(result.meta.search).toEqual({ title: '' })
-    })
-
-    describe('with search', () => {
-      it('should call formMetadata.list with provided search parameters', async () => {
-        const page = 1
-        const perPage = 10
-        const title = 'a search'
-        const totalItems = 2
-
-        const documents = [
-          { ...formMetadataFullDocument },
-          { ...formMetadataFullDocument }
-        ]
-
-        jest
-          .mocked(formMetadata.list)
-          .mockResolvedValue({ documents, totalItems })
-
-        const result = await listForms({ page, perPage, title })
-
-        expect(formMetadata.list).toHaveBeenCalledWith({
-          page,
-          perPage,
-          sortBy: 'updatedAt',
-          order: 'desc',
-          title
-        })
-
-        expect(result).toEqual({
-          data: expect.any(Array),
-          meta: {
-            pagination: {
-              page,
-              perPage,
-              totalItems,
-              totalPages: 1
-            },
-            search: {
-              title
-            },
-            sorting: {
-              sortBy: 'updatedAt',
-              order: 'desc'
-            }
-          }
-        })
-        expect(result.data).toHaveLength(documents.length)
-      })
-
-      it('should return empty results when search finds no matches', async () => {
-        const page = 1
-        const perPage = 10
-        const title = 'Defra Badger Relocation and Tea Party Planning Form'
-        const totalItems = 0
-
-        jest.mocked(formMetadata.list).mockResolvedValue({
-          documents: [],
-          totalItems
-        })
-
-        const result = await listForms({ page, perPage, title })
-
-        expect(formMetadata.list).toHaveBeenCalledWith({
-          page,
-          perPage,
-          sortBy: 'updatedAt',
-          order: 'desc',
-          title
-        })
-
-        expect(result).toEqual({
-          data: [],
-          meta: {
-            pagination: {
-              page,
-              perPage,
-              totalItems,
-              totalPages: 0
-            },
-            search: {
-              title
-            },
-            sorting: {
-              sortBy: 'updatedAt',
-              order: 'desc'
-            }
-          }
-        })
-      })
-
-      it('should use empty string for title when no search parameter is provided', async () => {
-        const page = 1
-        const perPage = 10
-        const totalItems = 1
-
-        jest.mocked(formMetadata.list).mockResolvedValue({
-          documents: [formMetadataFullDocument],
-          totalItems
-        })
-
-        const result = await listForms({ page, perPage })
-
-        expect(formMetadata.list).toHaveBeenCalledWith({
-          page,
-          perPage,
-          sortBy: 'updatedAt',
-          order: 'desc',
-          title: ''
-        })
-
-        expect(result.meta.search).toEqual({ title: '' })
+      expect(result).toEqual({
+        forms: [
+          expect.objectContaining({
+            updatedAt: formDate,
+            updatedBy: formAuthor,
+            createdAt: formDate,
+            createdBy: formAuthor
+          })
+        ],
+        totalItems: 1
       })
     })
   })

--- a/src/api/server.js
+++ b/src/api/server.js
@@ -9,6 +9,7 @@ import { failAction } from '~/src/helpers/fail-action.js'
 import { requestLogger } from '~/src/helpers/logging/request-logger.js'
 import { prepareDb } from '~/src/mongo.js'
 import { auth } from '~/src/plugins/auth/index.js'
+import { queryHandler } from '~/src/plugins/query-handler/index.js'
 import { router } from '~/src/plugins/router.js'
 import { transformErrors } from '~/src/plugins/transform-errors.js'
 import { prepareSecureContext } from '~/src/secure-context.js'
@@ -60,6 +61,7 @@ export async function createServer() {
 
   await server.register(auth)
   await server.register(requestLogger)
+  await server.register(queryHandler)
 
   if (isProduction) {
     prepareSecureContext(server)

--- a/src/plugins/query-handler/config.js
+++ b/src/plugins/query-handler/config.js
@@ -1,0 +1,20 @@
+import { MAX_RESULTS } from '~/src/api/forms/repositories/form-metadata-repository.js'
+
+/** @satisfies {QueryHandlerOptions} */
+export const defaultConfig = {
+  pagination: {
+    page: 1,
+    perPage: MAX_RESULTS
+  },
+  sorting: {
+    sortBy: 'updatedAt',
+    order: 'desc'
+  },
+  search: {
+    title: ''
+  }
+}
+
+/**
+ * @import { QueryHandlerOptions } from '~/src/plugins/query-handler/types.js'
+ */

--- a/src/plugins/query-handler/index.js
+++ b/src/plugins/query-handler/index.js
@@ -1,0 +1,58 @@
+import { defaultConfig } from '~/src/plugins/query-handler/config.js'
+
+/** @satisfies {ServerRegisterPluginObject<void>} */
+export const queryHandler = {
+  plugin: {
+    name: 'queryHandler',
+    register(server) {
+      server.decorate(
+        'toolkit',
+        'queryResponse',
+        /**
+         * @param {Array<*>} data
+         * @param {number} totalItems
+         * @param {QueryOptions} [options]
+         * @returns {QueryResult<*>}
+         */
+        function (data, totalItems, options) {
+          const defaults = {
+            page: defaultConfig.pagination.page,
+            perPage: defaultConfig.pagination.perPage,
+            sortBy: defaultConfig.sorting.sortBy,
+            order: defaultConfig.sorting.order,
+            title: defaultConfig.search.title
+          }
+
+          const { page, perPage, sortBy, order, title } = {
+            ...defaults,
+            ...options
+          }
+
+          return {
+            data,
+            meta: {
+              pagination: {
+                page,
+                perPage,
+                totalItems,
+                totalPages: Math.ceil(totalItems / perPage)
+              },
+              sorting: {
+                sortBy,
+                order
+              },
+              search: {
+                title
+              }
+            }
+          }
+        }
+      )
+    }
+  }
+}
+
+/**
+ * @import { ServerRegisterPluginObject } from '@hapi/hapi'
+ * @import { QueryOptions, QueryResult } from '@defra/forms-model'
+ */

--- a/src/plugins/query-handler/index.js
+++ b/src/plugins/query-handler/index.js
@@ -9,10 +9,11 @@ export const queryHandler = {
         'toolkit',
         'queryResponse',
         /**
-         * @param {Array<*>} data
+         * @template T
+         * @param {Array<T>} data
          * @param {number} totalItems
          * @param {QueryOptions} [options]
-         * @returns {QueryResult<*>}
+         * @returns {QueryResult<T>}
          */
         function (data, totalItems, options) {
           const defaults = {

--- a/src/plugins/query-handler/types.js
+++ b/src/plugins/query-handler/types.js
@@ -1,0 +1,26 @@
+/**
+ * @typedef {object} QueryHandlerToolkit
+ * @property {function(Array<*>, number, QueryOptions): QueryResult<*>} queryResponse - Creates a standardised response with pagination, sorting, and search metadata
+ */
+
+/**
+ * @typedef {object} QueryHandlerPlugin
+ * @property {string} name - The name of the plugin
+ * @property {(server: Server, options?: QueryHandlerOptions) => void | Promise<void>} register - Function to register the plugin with the server
+ */
+
+/**
+ * @typedef {object} QueryHandlerOptions
+ * @property {PaginationOptions} pagination - Options for configuring pagination behavior
+ * @property {SortingOptions} sorting - Options for configuring sorting behavior
+ * @property {SearchOptions} search - Options for configuring search behavior
+ */
+
+/**
+ * @typedef {ResponseToolkit & QueryHandlerToolkit} ExtendedResponseToolkit
+ */
+
+/**
+ * @import { QueryOptions, QueryResult, PaginationOptions, SortingOptions, SearchOptions } from '@defra/forms-model'
+ * @import { ResponseToolkit, Server } from '@hapi/hapi'
+ */

--- a/src/plugins/query-handler/types.js
+++ b/src/plugins/query-handler/types.js
@@ -1,6 +1,12 @@
 /**
- * @typedef {object} QueryHandlerToolkit
- * @property {function(Array<*>, number, QueryOptions): QueryResult<*>} queryResponse - Creates a standardised response with pagination, sorting, and search metadata
+ * @template T The type of items in the array
+ * @typedef {object} QueryHandlerToolkit<T>
+ * @property {function(Array<T>, number, QueryOptions): QueryResult<T>} queryResponse - Creates a standardised response with pagination, sorting, and search metadata
+ */
+
+/**
+ * @template T
+ * @typedef {ResponseToolkit & QueryHandlerToolkit<T>} ExtendedResponseToolkit
  */
 
 /**
@@ -14,10 +20,6 @@
  * @property {PaginationOptions} pagination - Options for configuring pagination behavior
  * @property {SortingOptions} sorting - Options for configuring sorting behavior
  * @property {SearchOptions} search - Options for configuring search behavior
- */
-
-/**
- * @typedef {ResponseToolkit & QueryHandlerToolkit} ExtendedResponseToolkit
  */
 
 /**

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -52,7 +52,7 @@ export default [
     path: '/forms',
     /**
      * @param {RequestListForms} request
-     * @param {ExtendedResponseToolkit} h
+     * @param {ExtendedResponseToolkit<FormMetadata>} h
      */
     async handler(request, h) {
       const { query } = request
@@ -298,7 +298,7 @@ export default [
 ]
 
 /**
- * @import { FormMetadataAuthor } from '@defra/forms-model'
+ * @import { FormMetadataAuthor, FormMetadata } from '@defra/forms-model'
  * @import { ServerRoute, UserCredentials } from '@hapi/hapi'
  * @import { OidcStandardClaims } from 'oidc-client-ts'
  * @import { RequestFormById, RequestFormBySlug, RequestFormDefinition, RequestFormMetadataCreate, RequestFormMetadataUpdateById, RequestListForms, RequestRemoveFormById } from '~/src/api/types.js'

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -52,10 +52,13 @@ export default [
     path: '/forms',
     /**
      * @param {RequestListForms} request
+     * @param {ExtendedResponseToolkit} h
      */
-    async handler(request) {
+    async handler(request, h) {
       const { query } = request
-      return listForms(query)
+
+      const { forms, totalItems } = await listForms(query)
+      return h.queryResponse(forms, totalItems, query)
     },
     options: {
       auth: false,
@@ -299,4 +302,5 @@ export default [
  * @import { ServerRoute, UserCredentials } from '@hapi/hapi'
  * @import { OidcStandardClaims } from 'oidc-client-ts'
  * @import { RequestFormById, RequestFormBySlug, RequestFormDefinition, RequestFormMetadataCreate, RequestFormMetadataUpdateById, RequestListForms, RequestRemoveFormById } from '~/src/api/types.js'
+ * @import { ExtendedResponseToolkit } from '~/src/plugins/query-handler/types.js'
  */

--- a/src/routes/forms.test.js
+++ b/src/routes/forms.test.js
@@ -95,22 +95,8 @@ describe('Forms route', () => {
   describe('Success responses', () => {
     test('GET /forms returns empty data array with default pagination, sorting, and search when no parameters are used', async () => {
       jest.mocked(listForms).mockResolvedValue({
-        data: [],
-        meta: {
-          pagination: {
-            page: 1,
-            perPage: 10,
-            totalItems: 0,
-            totalPages: 1
-          },
-          sorting: {
-            sortBy: 'updatedAt',
-            order: 'desc'
-          },
-          search: {
-            title: ''
-          }
-        }
+        forms: [],
+        totalItems: 0
       })
 
       const response = await server.inject({
@@ -126,9 +112,9 @@ describe('Forms route', () => {
         meta: {
           pagination: {
             page: 1,
-            perPage: 10,
+            perPage: 24,
             totalItems: 0,
-            totalPages: 1
+            totalPages: 0
           },
           sorting: {
             sortBy: 'updatedAt',
@@ -143,22 +129,8 @@ describe('Forms route', () => {
 
     test('GET /forms with search parameter returns filtered data and correct meta', async () => {
       jest.mocked(listForms).mockResolvedValue({
-        data: [stubFormMetadataOutput],
-        meta: {
-          pagination: {
-            page: 1,
-            perPage: 10,
-            totalItems: 1,
-            totalPages: 1
-          },
-          sorting: {
-            sortBy: 'updatedAt',
-            order: 'desc'
-          },
-          search: {
-            title: 'test'
-          }
-        }
+        forms: [stubFormMetadataOutput],
+        totalItems: 1
       })
 
       const response = await server.inject({
@@ -174,7 +146,7 @@ describe('Forms route', () => {
         meta: {
           pagination: {
             page: 1,
-            perPage: 10,
+            perPage: 24,
             totalItems: 1,
             totalPages: 1
           },
@@ -191,22 +163,8 @@ describe('Forms route', () => {
 
     test('GET /forms with search, pagination and sorting parameters returns filtered, sorted paginated data', async () => {
       jest.mocked(listForms).mockResolvedValue({
-        data: [stubFormMetadataOutput],
-        meta: {
-          pagination: {
-            page: 1,
-            perPage: 5,
-            totalItems: 1,
-            totalPages: 1
-          },
-          sorting: {
-            sortBy: 'title',
-            order: 'asc'
-          },
-          search: {
-            title: 'test'
-          }
-        }
+        forms: [stubFormMetadataOutput],
+        totalItems: 1
       })
 
       const response = await server.inject({
@@ -239,19 +197,8 @@ describe('Forms route', () => {
 
     test('GET /forms with sorting parameters returns sorted data and correct meta', async () => {
       jest.mocked(listForms).mockResolvedValue({
-        data: [stubFormMetadataOutput],
-        meta: {
-          pagination: {
-            page: 1,
-            perPage: 10,
-            totalItems: 1,
-            totalPages: 1
-          },
-          sorting: {
-            sortBy: 'title',
-            order: 'asc'
-          }
-        }
+        forms: [stubFormMetadataOutput],
+        totalItems: 1
       })
 
       const response = await server.inject({
@@ -262,19 +209,21 @@ describe('Forms route', () => {
 
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
-
       expect(response.result).toEqual({
         data: [stubFormMetadataOutput],
         meta: {
           pagination: {
             page: 1,
-            perPage: 10,
+            perPage: 24,
             totalItems: 1,
             totalPages: 1
           },
           sorting: {
             sortBy: 'title',
             order: 'asc'
+          },
+          search: {
+            title: ''
           }
         }
       })
@@ -282,19 +231,8 @@ describe('Forms route', () => {
 
     test('GET /forms with pagination and sorting parameters returns sorted paginated data', async () => {
       jest.mocked(listForms).mockResolvedValue({
-        data: [stubFormMetadataOutput],
-        meta: {
-          pagination: {
-            page: 1,
-            perPage: 5,
-            totalItems: 1,
-            totalPages: 1
-          },
-          sorting: {
-            sortBy: 'title',
-            order: 'asc'
-          }
-        }
+        forms: [stubFormMetadataOutput],
+        totalItems: 1
       })
 
       const response = await server.inject({
@@ -305,7 +243,6 @@ describe('Forms route', () => {
 
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
-
       expect(response.result).toEqual({
         data: [stubFormMetadataOutput],
         meta: {
@@ -318,6 +255,9 @@ describe('Forms route', () => {
           sorting: {
             sortBy: 'title',
             order: 'asc'
+          },
+          search: {
+            title: ''
           }
         }
       })
@@ -325,19 +265,8 @@ describe('Forms route', () => {
 
     test('GET /forms with pagination parameters returns paginated data and default sorting', async () => {
       jest.mocked(listForms).mockResolvedValue({
-        data: [stubFormMetadataOutput],
-        meta: {
-          pagination: {
-            page: 1,
-            perPage: 10,
-            totalItems: 1,
-            totalPages: 1
-          },
-          sorting: {
-            sortBy: 'updatedAt',
-            order: 'desc'
-          }
-        }
+        forms: [stubFormMetadataOutput],
+        totalItems: 1
       })
 
       const response = await server.inject({
@@ -348,30 +277,11 @@ describe('Forms route', () => {
 
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
-
       expect(response.result).toEqual({
         data: [stubFormMetadataOutput],
         meta: {
           pagination: {
             page: 1,
-            perPage: 10,
-            totalItems: 1,
-            totalPages: 1
-          },
-          sorting: {
-            sortBy: 'updatedAt',
-            order: 'desc'
-          }
-        }
-      })
-    })
-
-    test('GET /forms with pagination parameters returns empty data array and default sorting when no forms are available', async () => {
-      jest.mocked(listForms).mockResolvedValue({
-        data: [],
-        meta: {
-          pagination: {
-            page: 2,
             perPage: 10,
             totalItems: 1,
             totalPages: 1
@@ -385,6 +295,13 @@ describe('Forms route', () => {
           }
         }
       })
+    })
+
+    test('GET /forms with pagination parameters returns empty data array and default sorting when no forms are available', async () => {
+      jest.mocked(listForms).mockResolvedValue({
+        forms: [],
+        totalItems: 1
+      })
 
       const response = await server.inject({
         method: 'GET',
@@ -394,7 +311,6 @@ describe('Forms route', () => {
 
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
-
       expect(response.result).toEqual({
         data: [],
         meta: {


### PR DESCRIPTION
## Description
Adds a Hapi plugin that provides a consistent response format for list endpoints, including:
- Pagination metadata (page, perPage, totalItems, totalPages)
- Sorting metadata (sortBy, order)
- Search metadata (title)
- Configurable defaults

Cleans up response handling by separating response formatting from business logic in the service where it previously was, making it easily extendable for new metadata types such as the incoming advanced search fields. And it's a nice way to align with our n-tier architecture by centralising response formatting at the controller/route layer.

