### PR TITLE
Clean up draft form deletion

### DIFF
--- a/src/api/forms/constants.js
+++ b/src/api/forms/constants.js
@@ -12,3 +12,7 @@ export const makeFormLiveErrorMessages = {
   missingPrivacyNotice:
     'You need to add a link to the privacy notice before you can publish this form.'
 }
+
+export const removeFormErrorMessages = {
+  formIsAlreadyLive: 'This form has already gone live and cannot be deleted.'
+}

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -648,30 +648,12 @@ describe('Forms service', () => {
       await expect(removeForm(id)).rejects.toBeDefined()
     })
 
-    it('should fail if the form is live but not being force deleted', async () => {
+    it('should fail if the form is live', async () => {
       jest
         .mocked(formMetadata.get)
         .mockResolvedValueOnce(formMetadataWithLiveDocument)
 
       await expect(removeForm(id)).rejects.toBeDefined()
-    })
-
-    it('should succeed if the form is live and being force deleted', async () => {
-      jest
-        .mocked(formMetadata.get)
-        .mockResolvedValueOnce(formMetadataWithLiveDocument)
-
-      await expect(removeForm(id, true)).resolves.toBeUndefined()
-    })
-
-    it('should succeed if form definition deletion fails and the form is being force deleted', async () => {
-      jest
-        .mocked(formMetadata.get)
-        .mockResolvedValueOnce(formMetadataWithLiveDocument)
-
-      jest.mocked(formDefinition.remove).mockRejectedValueOnce('unknown error')
-
-      await expect(removeForm(id, true)).resolves.toBeUndefined()
     })
   })
 

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -4,7 +4,6 @@
  * @typedef {Request<{ Server: { db: Db }, Params: FormBySlugInput }>} RequestFormBySlug
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: FormDefinition }>} RequestFormDefinition
  * @typedef {Request<{ Server: { db: Db }, Payload: FormMetadataInput }>} RequestFormMetadataCreate
- * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: { force: boolean }}>} RequestRemoveFormById
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: Partial<FormMetadataInput> }>} RequestFormMetadataUpdateById
  * @typedef {Request<{ Server: { db: Db }, Query: QueryOptions }>} RequestListForms
  */

--- a/src/models/forms.js
+++ b/src/models/forms.js
@@ -6,20 +6,12 @@ import {
 } from '@defra/forms-model'
 import Joi from 'joi'
 
-const forceRemoveDefault = false
-
 // Retrieve form by ID schema
 export const formByIdSchema = Joi.object()
   .keys({
     id: idSchema
   })
   .required()
-
-// Remove form payload schema
-export const removeFormPayloadSchema = Joi.object()
-  .keys({ force: Joi.boolean().default(forceRemoveDefault) }) // handle object payloads
-  .default({ force: forceRemoveDefault }) // handle null payloads
-  .empty(null)
 
 // Retrieve form by slug schema
 export const formBySlugSchema = Joi.object()

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -21,7 +21,6 @@ import {
   createFormSchema,
   formByIdSchema,
   formBySlugSchema,
-  removeFormPayloadSchema,
   updateFormDefinitionSchema
 } from '~/src/models/forms.js'
 
@@ -163,24 +162,21 @@ export default [
     method: 'DELETE',
     path: '/forms/{id}',
     /**
-     * @param {RequestRemoveFormById} request
+     * @param {RequestFormById} request
      */
     async handler(request) {
-      const { params, payload } = request
-      const { id } = params
-      const { force } = payload
+      const { id } = request.params
 
-      await removeForm(id, force)
+      await removeForm(id)
 
       return {
-        id: params.id,
+        id,
         status: 'deleted'
       }
     },
     options: {
       validate: {
-        params: formByIdSchema,
-        payload: removeFormPayloadSchema
+        params: formByIdSchema
       }
     }
   },


### PR DESCRIPTION
- Remove force option now that our form defs are all in Mongo
  - We previously stored our form definitions separately to the form metadata. Form defs would be in S3, metadata in Mongo. We had no referential integrity so we needed a force option to allow form metadata to be deleted if the definition didn't exist, otherwise the operation would fail.
  - Since we no longer use S3 for form defs, we can drop the `force` option.
- Improve the error message for form deletion to align to the friendly error messages returned by other endpoints