### PR TITLE
Feature 479076: Advanced Search and filters

### DIFF
--- a/src/api/forms/repositories/aggregation/form-metadata-aggregation.js
+++ b/src/api/forms/repositories/aggregation/form-metadata-aggregation.js
@@ -1,11 +1,12 @@
 import { escapeRegExp } from '~/src/helpers/string-utils.js'
 
 /**
- * Builds the filter conditions for querying forms by title.
- * @param {string} title - The title to filter by.
+ * Builds the filter conditions for querying forms.
+ * @param {FilterQuery} options - The filter query options
  * @returns {FilterConditions} The filter conditions for MongoDB query.
  */
-export function buildFilterConditions(title) {
+export function buildFilterConditions(options) {
+  const { title, author, organisations, status } = options
   const conditions = {}
 
   if (title) {
@@ -13,7 +14,66 @@ export function buildFilterConditions(title) {
     conditions.title = { $regex: regex }
   }
 
+  if (author) {
+    const regex = new RegExp(escapeRegExp(author), 'i')
+    conditions['createdBy.displayName'] = { $regex: regex }
+  }
+
+  if (organisations && organisations.length > 0) {
+    conditions.organisation = { $in: organisations }
+  }
+
+  if (status && status.length > 0) {
+    conditions.$or = status.map((s) =>
+      s === 'live' ? { live: { $exists: true } } : { live: { $exists: false } }
+    )
+  }
+
   return conditions
+}
+
+/**
+ * Builds the filters facet pipeline stage
+ * @see {@link https://www.mongodb.com/docs/manual/reference/operator/aggregation/facet/}
+ * @returns {{ $facet: { authors: PipelineStage[], organisations: PipelineStage[], status: PipelineStage[] } }} The facet pipeline stage for getting filter options
+ */
+export function buildFiltersFacet() {
+  return {
+    $facet: {
+      authors: [
+        {
+          $group: {
+            _id: '$createdBy.displayName' // Groups documents by author name, removing duplicates
+          }
+        },
+        {
+          $project: {
+            _id: 0,
+            name: '$_id' // Renames _id to name for cleaner output
+          }
+        },
+        { $sort: { name: 1 } } // Sorts alphabetically (1 = ascending)
+      ],
+      organisations: [
+        { $group: { _id: '$organisation' } },
+        { $project: { name: '$_id', _id: 0 } },
+        { $sort: { name: 1 } }
+      ],
+      status: [
+        {
+          $group: {
+            _id: null, // Single group for all documents
+            statuses: {
+              $addToSet: {
+                $cond: [{ $ifNull: ['$live', false] }, 'live', 'draft'] // If live field exists, status is 'live', else 'draft'
+              }
+            }
+          }
+        },
+        { $project: { statuses: 1, _id: 0 } }
+      ]
+    }
+  }
 }
 
 /**
@@ -21,11 +81,26 @@ export function buildFilterConditions(title) {
  * @param {string} sortBy - Field to sort by ('updatedAt' or 'title').
  * @param {string} order - Sort order ('asc' or 'desc').
  * @param {string} title - The title to filter by.
- * @returns {{ pipeline: PipelineStage[], aggOptions: AggregateOptions }} The pipeline stages and aggregation options.
+ * @param {string} author - The author to filter by.
+ * @param {string[]} organisations - The organisations to filter by.
+ * @param {FormStatus[]} status - The status values to filter by.
+ * @returns {{ pipeline: PipelineStage[], aggOptions: AggregateOptions }}
  */
-export function buildAggregationPipeline(sortBy, order, title) {
+export function buildAggregationPipeline(
+  sortBy,
+  order,
+  title,
+  author,
+  organisations,
+  status
+) {
   const pipeline = []
-  const filterConditions = buildFilterConditions(title)
+  const filterConditions = buildFilterConditions({
+    title,
+    author,
+    organisations,
+    status
+  })
 
   // Add $match stage if there are filter conditions
   if (Object.keys(filterConditions).length > 0) {
@@ -45,6 +120,7 @@ export function buildAggregationPipeline(sortBy, order, title) {
 
 /**
  * Adds the ranking stage to the pipeline based on the title.
+ * @see {@link https://www.mongodb.com/docs/manual/reference/operator/aggregation/rank/}
  * @param {PipelineStage[]} pipeline - The aggregation pipeline stages.
  * @param {string} title - The title to filter by.
  */
@@ -104,6 +180,7 @@ export function addRankingStage(pipeline, title) {
 
 /**
  * Adds the date field stage to the pipeline to extract date only from 'updatedAt'.
+ * @see {@link https://www.mongodb.com/docs/manual/reference/operator/aggregation/dateToString/}
  * @param {PipelineStage[]} pipeline - The aggregation pipeline stages.
  */
 export function addDateFieldStage(pipeline) {
@@ -123,6 +200,7 @@ export function addDateFieldStage(pipeline) {
 
 /**
  * Adds the sorting stage to the pipeline based on the sortBy parameter.
+ * @see {@link https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/}
  * @param {PipelineStage[]} pipeline - The aggregation pipeline stages.
  * @param {string} sortBy - Field to sort by ('updatedAt' or 'title').
  * @param {string} order - Sort order ('asc' or 'desc').
@@ -169,7 +247,26 @@ export function addSortingStage(pipeline, sortBy, order) {
 }
 
 /**
- * @import { AddFieldsSwitch, FilterConditions, PipelineStage } from '~/src/api/forms/repositories/aggregation/types.js'
+ * Processes author names from aggregation results, filtering out invalid values
+ * @param {{name: string}[]} authors - Array of author objects from aggregation
+ * @returns {string[]} Filtered array of valid author names
+ *
+ * This is a temp workaround for the fact that the author name (given_name and family_name)
+ * is sometimes undefined due to not being register with a Defra account, although we've
+ * changed that now to default to their display name when creating or updating a form
+ */
+export function processAuthorNames(authors) {
+  return authors
+    .map((author) => author.name)
+    .filter((name) => name && name !== 'undefined undefined')
+}
+
+/**
+ * @import { AddFieldsSwitch, FilterConditions, FilterQuery, PipelineStage } from '~/src/api/forms/repositories/aggregation/types.js'
+ */
+
+/**
+ * @import { FormStatus } from '@defra/forms-model'
  */
 
 /**

--- a/src/api/forms/repositories/aggregation/form-metadata-aggregation.js
+++ b/src/api/forms/repositories/aggregation/form-metadata-aggregation.js
@@ -262,11 +262,23 @@ export function processAuthorNames(authors) {
 }
 
 /**
- * @import { AddFieldsSwitch, FilterConditions, FilterQuery, PipelineStage } from '~/src/api/forms/repositories/aggregation/types.js'
+ * Processes filter results from aggregation into a structured FilterOptions object
+ * @param {FilterAggregationResult} filterResults - Raw filter results from aggregation
+ */
+export function processFilterResults(filterResults) {
+  return {
+    authors: processAuthorNames(filterResults.authors),
+    organisations: filterResults.organisations.map((org) => org.name),
+    statuses: filterResults.status[0].statuses
+  }
+}
+
+/**
+ * @import { AddFieldsSwitch, FilterConditions, FilterQuery, PipelineStage, FilterAggregationResult } from '~/src/api/forms/repositories/aggregation/types.js'
  */
 
 /**
- * @import { FormStatus } from '@defra/forms-model'
+ * @import { FormStatus, FilterOptions } from '@defra/forms-model'
  */
 
 /**

--- a/src/api/forms/repositories/aggregation/form-metadata-aggregation.test.js
+++ b/src/api/forms/repositories/aggregation/form-metadata-aggregation.test.js
@@ -5,7 +5,8 @@ import {
   buildAggregationPipeline,
   buildFilterConditions,
   buildFiltersFacet,
-  processAuthorNames
+  processAuthorNames,
+  processFilterResults
 } from '~/src/api/forms/repositories/aggregation/form-metadata-aggregation.js'
 
 describe('Form metadata aggregation', () => {
@@ -293,8 +294,48 @@ describe('Form metadata aggregation', () => {
       expect(processAuthorNames([])).toEqual([])
     })
   })
+
+  describe('processFilterResults', () => {
+    it('should process filter results into FilterOptions structure', () => {
+      /** @type {FilterAggregationResult} */
+      const filterResults = {
+        authors: [
+          { name: 'Enrique Chase (Defra)' },
+          { name: 'undefined undefined' },
+          { name: 'Sarah Wilson (Natural England)' }
+        ],
+        organisations: [{ name: 'Defra' }, { name: 'Natural England' }],
+        status: [{ statuses: ['live', 'draft'] }]
+      }
+
+      const result = processFilterResults(filterResults)
+
+      expect(result).toEqual({
+        authors: ['Enrique Chase (Defra)', 'Sarah Wilson (Natural England)'],
+        organisations: ['Defra', 'Natural England'],
+        statuses: ['live', 'draft']
+      })
+    })
+
+    it('should handle empty filter results', () => {
+      /** @type {FilterAggregationResult} */
+      const filterResults = {
+        authors: [],
+        organisations: [],
+        status: [{ statuses: [] }]
+      }
+
+      const result = processFilterResults(filterResults)
+
+      expect(result).toEqual({
+        authors: [],
+        organisations: [],
+        statuses: []
+      })
+    })
+  })
 })
 
 /**
- * @import { AddFieldsSwitch, PipelineStage } from '~/src/api/forms/repositories/aggregation/types.js'
+ * @import { AddFieldsSwitch, PipelineStage, FilterAggregationResult } from '~/src/api/forms/repositories/aggregation/types.js'
  */

--- a/src/api/forms/repositories/aggregation/types.js
+++ b/src/api/forms/repositories/aggregation/types.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {object} FilterConditions
  * @property {{ $regex: RegExp }} [title] - Optional MongoDB regex query for title matching
- * @property {{ $regex: RegExp }} [createdBy.displayName] - Optional MongoDB regex query for author matching
+ * @property {{ displayName: { $regex: RegExp } }} [createdBy] - Optional MongoDB regex query for author matching
  * @property {{ $in: string[] }} [organisation] - Optional MongoDB $in query for organisation matching
  * @property {{ live: { $exists: boolean } }[]} [$or] - Optional MongoDB $or query for status matching
  */

--- a/src/api/forms/repositories/aggregation/types.js
+++ b/src/api/forms/repositories/aggregation/types.js
@@ -1,6 +1,20 @@
 /**
  * @typedef {object} FilterConditions
  * @property {{ $regex: RegExp }} [title] - Optional MongoDB regex query for title matching
+ * @property {{ $regex: RegExp }} [createdBy.displayName] - Optional MongoDB regex query for author matching
+ * @property {{ $in: string[] }} [organisation] - Optional MongoDB $in query for organisation matching
+ * @property {{ live: { $exists: boolean } }[]} [$or] - Optional MongoDB $or query for status matching
+ */
+
+/**
+ * @typedef {SearchOptions & { title?: string }} FilterQuery
+ */
+
+/**
+ * @typedef {object} FilterAggregationResult
+ * @property {{ name: string }[]} authors - Array of author names
+ * @property {{ name: string }[]} organisations - Array of organisation names
+ * @property {[{ statuses: FormStatus[] }]} status - Array containing status values
  */
 
 /**
@@ -52,9 +66,16 @@
 
 /**
  * @typedef {object} PipelineStage
- * @property {FilterConditions} [$match] - MongoDB $match stage for filtering documents
- * @property {AddFieldsStage} [$addFields] - MongoDB $addFields stage for adding computed fields to documents
- * @property {{ [key: string]: 1 | -1 }} [$sort] - MongoDB $sort stage for sorting documents
- * @property {number} [$skip] - MongoDB $skip stage for pagination
- * @property {number} [$limit] - MongoDB $limit stage for limiting results
+ * @property {FilterConditions} [$match] - MongoDB $match stage
+ * @property {AddFieldsStage} [$addFields] - MongoDB $addFields stage
+ * @property {{ [key: string]: 1 | -1 }} [$sort] - MongoDB $sort stage
+ * @property {number} [$skip] - MongoDB $skip stage
+ * @property {number} [$limit] - MongoDB $limit stage
+ * @property {{ [key: string]: PipelineStage[] }} [$facet] - MongoDB $facet stage
+ * @property {{ _id: string | null | object, [key: string]: any }} [$group] - MongoDB $group stage
+ * @property {{ [key: string]: 0 | 1 | string }} [$project] - MongoDB $project stage
+ */
+
+/**
+ * @import { SearchOptions, FormStatus } from '@defra/forms-model'
  */

--- a/src/api/forms/repositories/form-metadata-repository.js
+++ b/src/api/forms/repositories/form-metadata-repository.js
@@ -6,7 +6,7 @@ import {
   buildAggregationPipeline,
   buildFilterConditions,
   buildFiltersFacet,
-  processAuthorNames
+  processFilterResults
 } from '~/src/api/forms/repositories/aggregation/form-metadata-aggregation.js'
 import { removeById } from '~/src/api/forms/repositories/helpers.js'
 import { createLogger } from '~/src/helpers/logging/logger.js'
@@ -62,11 +62,7 @@ export async function list(options) {
       await coll.aggregate([buildFiltersFacet()]).toArray()
     )
 
-    const filters = {
-      authors: processAuthorNames(filterResults.authors),
-      organisations: filterResults.organisations.map((org) => org.name),
-      statuses: filterResults.status[0].statuses
-    }
+    const filters = processFilterResults(filterResults)
 
     const { pipeline, aggOptions } = buildAggregationPipeline(
       sortBy,

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -166,14 +166,15 @@ export async function createForm(metadataInput, author) {
 }
 
 /**
- * Retrieves a paginated list of forms
+ * Retrieves a paginated list of forms with filter options
  * @param {QueryOptions} options - Pagination, sorting, and filtering options
- * @returns {Promise<{ forms: FormMetadata[], totalItems: number }>}
+ * @returns {Promise<{ forms: FormMetadata[], totalItems: number, filters: FilterOptions }>}
  */
 export async function listForms(options) {
-  const { documents, totalItems } = await formMetadata.list(options)
+  const { documents, totalItems, filters } = await formMetadata.list(options)
   const forms = documents.map(mapForm)
-  return { forms, totalItems }
+
+  return { forms, totalItems, filters }
 }
 
 /**
@@ -505,7 +506,7 @@ export async function removeForm(formId) {
 }
 
 /**
- * @import { FormDefinition, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, FormMetadata, QueryResult, QueryOptions } from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, FormMetadata, FilterOptions, QueryOptions } from '@defra/forms-model'
  * @import { WithId } from 'mongodb'
  * @import { PartialFormMetadataDocument} from '~/src/api/types.js'
  */

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -161,6 +161,15 @@ describe('Forms service', () => {
     updatedBy: author
   }
 
+  /**
+   * @satisfies {FilterOptions}
+   */
+  const mockFilters = {
+    authors: ['Joe Bloggs', 'Jane Doe', 'Enrique Chase'],
+    organisations: ['Defra', 'Natural England'],
+    status: ['live', 'draft']
+  }
+
   let definition = actualEmptyForm()
 
   beforeAll(async () => {
@@ -732,7 +741,8 @@ describe('Forms service', () => {
     it('should handle the full set of states', async () => {
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [formMetadataFullDocument],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
 
       const result = await listForms({ page: 1, perPage: 10 })
@@ -746,14 +756,16 @@ describe('Forms service', () => {
             createdBy: formAuthor
           })
         ],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
     })
 
     it('should handle states when root state info is missing and live is present', async () => {
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [formMetadataDraftDocument],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
 
       const result = await listForms({ page: 1, perPage: 10 })
@@ -767,14 +779,16 @@ describe('Forms service', () => {
             createdBy: liveAuthor
           })
         ],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
     })
 
     it('should handle states when draft state info is missing', async () => {
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [formMetadataLiveDocument],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
 
       const result = await listForms({ page: 1, perPage: 10 })
@@ -788,14 +802,16 @@ describe('Forms service', () => {
             createdBy: liveAuthor
           })
         ],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
     })
 
     it('should handle states when live state info is missing', async () => {
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [formMetadataDraftNoLiveDocument],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
 
       const result = await listForms({ page: 1, perPage: 10 })
@@ -809,14 +825,16 @@ describe('Forms service', () => {
             createdBy: draftAuthor
           })
         ],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
     })
 
     it('should handle states when all states are missing', async () => {
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [formMetadataBaseDocument],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
 
       const result = await listForms({ page: 1, perPage: 10 })
@@ -830,7 +848,8 @@ describe('Forms service', () => {
             createdBy: defaultAuthor
           })
         ],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
     })
 
@@ -851,7 +870,7 @@ describe('Forms service', () => {
 
         jest
           .mocked(formMetadata.list)
-          .mockResolvedValue({ documents, totalItems })
+          .mockResolvedValue({ documents, totalItems, filters: mockFilters })
 
         const options = { page, perPage, sortBy, order, title }
         const result = await listForms(options)
@@ -859,7 +878,8 @@ describe('Forms service', () => {
         expect(formMetadata.list).toHaveBeenCalledWith(options)
         expect(result).toEqual({
           forms: expect.any(Array),
-          totalItems
+          totalItems,
+          filters: mockFilters
         })
       })
     })
@@ -872,7 +892,8 @@ describe('Forms service', () => {
 
         jest.mocked(formMetadata.list).mockResolvedValue({
           documents: [formMetadataFullDocument, formMetadataFullDocument],
-          totalItems: 2
+          totalItems: 2,
+          filters: mockFilters
         })
 
         const result = await listForms({ page, perPage, title })
@@ -884,7 +905,8 @@ describe('Forms service', () => {
         })
         expect(result).toEqual({
           forms: expect.any(Array),
-          totalItems: 2
+          totalItems: 2,
+          filters: mockFilters
         })
       })
 
@@ -895,7 +917,8 @@ describe('Forms service', () => {
 
         jest.mocked(formMetadata.list).mockResolvedValue({
           documents: [],
-          totalItems: 0
+          totalItems: 0,
+          filters: mockFilters
         })
 
         const result = await listForms({ page, perPage, title })
@@ -907,7 +930,8 @@ describe('Forms service', () => {
         })
         expect(result).toEqual({
           forms: [],
-          totalItems: 0
+          totalItems: 0,
+          filters: mockFilters
         })
       })
 
@@ -917,7 +941,8 @@ describe('Forms service', () => {
 
         jest.mocked(formMetadata.list).mockResolvedValue({
           documents: [formMetadataFullDocument],
-          totalItems: 1
+          totalItems: 1,
+          filters: mockFilters
         })
 
         const result = await listForms({ page, perPage })
@@ -928,7 +953,8 @@ describe('Forms service', () => {
         })
         expect(result).toEqual({
           forms: expect.any(Array),
-          totalItems: 1
+          totalItems: 1,
+          filters: mockFilters
         })
       })
     })
@@ -936,7 +962,8 @@ describe('Forms service', () => {
     it('should handle default pagination parameters', async () => {
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [formMetadataFullDocument],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
 
       const result = await listForms({
@@ -957,7 +984,8 @@ describe('Forms service', () => {
             createdBy: formAuthor
           })
         ],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
     })
 
@@ -966,7 +994,8 @@ describe('Forms service', () => {
 
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [formMetadataFullDocument],
-        totalItems
+        totalItems,
+        filters: mockFilters
       })
 
       const result = await listForms({
@@ -983,14 +1012,16 @@ describe('Forms service', () => {
             createdBy: formAuthor
           })
         ],
-        totalItems
+        totalItems,
+        filters: mockFilters
       })
     })
 
     it('should handle empty results with MAX_RESULTS', async () => {
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [],
-        totalItems: 0
+        totalItems: 0,
+        filters: mockFilters
       })
 
       const result = await listForms({
@@ -1000,14 +1031,16 @@ describe('Forms service', () => {
 
       expect(result).toEqual({
         forms: [],
-        totalItems: 0
+        totalItems: 0,
+        filters: mockFilters
       })
     })
 
     it('should use default values when no options are provided', async () => {
       jest.mocked(formMetadata.list).mockResolvedValue({
         documents: [formMetadataFullDocument],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
       })
 
       const result = await listForms({ page: 1, perPage: MAX_RESULTS })
@@ -1025,7 +1058,84 @@ describe('Forms service', () => {
             createdBy: formAuthor
           })
         ],
-        totalItems: 1
+        totalItems: 1,
+        filters: mockFilters
+      })
+    })
+
+    describe('with filters', () => {
+      it('should return empty filters when no forms exist', async () => {
+        const emptyFilters = {
+          authors: [],
+          organisations: [],
+          status: []
+        }
+
+        jest.mocked(formMetadata.list).mockResolvedValue({
+          documents: [],
+          totalItems: 0,
+          filters: emptyFilters
+        })
+
+        const result = await listForms({ page: 1, perPage: 10 })
+
+        expect(result).toEqual({
+          forms: [],
+          totalItems: 0,
+          filters: emptyFilters
+        })
+      })
+
+      it('should pass filter parameters to repository', async () => {
+        /** @type {QueryOptions} */
+        const options = {
+          page: 1,
+          perPage: 10,
+          author: 'Henrique Chase',
+          organisations: ['Defra'],
+          status: ['live']
+        }
+
+        jest.mocked(formMetadata.list).mockResolvedValue({
+          documents: [formMetadataFullDocument],
+          totalItems: 1,
+          filters: mockFilters
+        })
+
+        const result = await listForms(options)
+
+        expect(formMetadata.list).toHaveBeenCalledWith(options)
+        expect(result).toEqual({
+          forms: expect.any(Array),
+          totalItems: 1,
+          filters: mockFilters
+        })
+      })
+
+      it('should handle multiple filter parameters', async () => {
+        /** @type {QueryOptions} */
+        const options = {
+          page: 1,
+          perPage: 10,
+          author: 'Henrique Chase',
+          organisations: ['Defra', 'Natural England'],
+          status: ['live', 'draft']
+        }
+
+        jest.mocked(formMetadata.list).mockResolvedValue({
+          documents: [formMetadataFullDocument, formMetadataFullDocument],
+          totalItems: 2,
+          filters: mockFilters
+        })
+
+        const result = await listForms(options)
+
+        expect(formMetadata.list).toHaveBeenCalledWith(options)
+        expect(result).toEqual({
+          forms: expect.any(Array),
+          totalItems: 2,
+          filters: mockFilters
+        })
       })
     })
   })
@@ -1120,6 +1230,6 @@ describe('Forms service', () => {
 })
 
 /**
- * @import { FormDefinition, FormMetadata, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, QueryResult } from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadata, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, FilterOptions, QueryOptions } from '@defra/forms-model'
  * @import { WithId } from 'mongodb'
  */

--- a/src/helpers/get-author.js
+++ b/src/helpers/get-author.js
@@ -1,0 +1,30 @@
+import Boom from '@hapi/boom'
+
+/**
+ * Get the author from the auth credentials
+ * @param {UserCredentials & OidcStandardClaims} [user]
+ * @returns {FormMetadataAuthor}
+ */
+export function getAuthor(user) {
+  if (!user || !user.oid || !user.name) {
+    throw Boom.unauthorized(
+      'Failed to get the author. User is undefined or has a malformed/missing oid/name.'
+    )
+  }
+
+  const displayName =
+    user.given_name && user.family_name
+      ? `${user.given_name} ${user.family_name}`
+      : user.name
+
+  return {
+    id: user.oid,
+    displayName
+  }
+}
+
+/**
+ * @import { FormMetadataAuthor } from '@defra/forms-model'
+ * @import { UserCredentials } from '@hapi/hapi'
+ * @import { OidcStandardClaims } from 'oidc-client-ts'
+ */

--- a/src/helpers/get-author.js
+++ b/src/helpers/get-author.js
@@ -6,7 +6,7 @@ import Boom from '@hapi/boom'
  * @returns {FormMetadataAuthor}
  */
 export function getAuthor(user) {
-  if (!user || !user.oid || !user.name) {
+  if (!user?.oid || !user.name) {
     throw Boom.unauthorized(
       'Failed to get the author. User is undefined or has a malformed/missing oid/name.'
     )

--- a/src/helpers/get-author.test.js
+++ b/src/helpers/get-author.test.js
@@ -1,0 +1,76 @@
+import Boom from '@hapi/boom'
+
+import { getAuthor } from '~/src/helpers/get-author.js'
+
+describe('getAuthor', () => {
+  describe('when user has valid credentials', () => {
+    it('should return author with combined given and family name when available', () => {
+      const user = {
+        oid: '86758ba9-92e7-4287-9751-7705e449688e',
+        name: 'Enrique Chase (Defra)',
+        given_name: 'Enrique',
+        family_name: 'Chase'
+      }
+
+      const result = getAuthor(user)
+
+      expect(result).toEqual({
+        id: '86758ba9-92e7-4287-9751-7705e449688e',
+        displayName: 'Enrique Chase'
+      })
+    })
+
+    it('should return author with name when given/family names not available', () => {
+      const user = {
+        oid: '86758ba9-92e7-4287-9751-7705e449688e',
+        name: 'Enrique Chase (Defra)'
+      }
+
+      const result = getAuthor(user)
+
+      expect(result).toEqual({
+        id: '86758ba9-92e7-4287-9751-7705e449688e',
+        displayName: 'Enrique Chase (Defra)'
+      })
+    })
+  })
+
+  describe('when user has invalid credentials', () => {
+    it('should throw unauthorised when user is undefined', () => {
+      expect(() => getAuthor(undefined)).toThrow(
+        Boom.unauthorized(
+          'Failed to get the author. User is undefined or has a malformed/missing oid/name.'
+        )
+      )
+    })
+
+    it('should throw unauthorised when oid is missing', () => {
+      const user = {
+        name: 'Enrique Chase (Defra)'
+      }
+
+      expect(() => getAuthor(user)).toThrow(
+        Boom.unauthorized(
+          'Failed to get the author. User is undefined or has a malformed/missing oid/name.'
+        )
+      )
+    })
+
+    it('should throw unauthorised when name is missing', () => {
+      const user = {
+        oid: '86758ba9-92e7-4287-9751-7705e449688e'
+      }
+
+      expect(() => getAuthor(user)).toThrow(
+        Boom.unauthorized(
+          'Failed to get the author. User is undefined or has a malformed/missing oid/name.'
+        )
+      )
+    })
+  })
+})
+
+/**
+ * @import { UserCredentials } from '@hapi/hapi'
+ * @import { OidcStandardClaims } from 'oidc-client-ts'
+ */

--- a/src/plugins/query-handler/config.js
+++ b/src/plugins/query-handler/config.js
@@ -11,7 +11,10 @@ export const defaultConfig = {
     order: 'desc'
   },
   search: {
-    title: ''
+    title: '',
+    author: '',
+    organisations: [],
+    status: []
   }
 }
 

--- a/src/plugins/query-handler/index.js
+++ b/src/plugins/query-handler/index.js
@@ -13,18 +13,31 @@ export const queryHandler = {
          * @param {Array<T>} data
          * @param {number} totalItems
          * @param {QueryOptions} [options]
+         * @param {FilterOptions} [filters]
          * @returns {QueryResult<T>}
          */
-        function (data, totalItems, options) {
+        function (data, totalItems, options, filters) {
           const defaults = {
             page: defaultConfig.pagination.page,
             perPage: defaultConfig.pagination.perPage,
             sortBy: defaultConfig.sorting.sortBy,
             order: defaultConfig.sorting.order,
-            title: defaultConfig.search.title
+            title: defaultConfig.search.title,
+            author: defaultConfig.search.author,
+            organisations: defaultConfig.search.organisations,
+            status: defaultConfig.search.status
           }
 
-          const { page, perPage, sortBy, order, title } = {
+          const {
+            page,
+            perPage,
+            sortBy,
+            order,
+            title,
+            author,
+            organisations,
+            status
+          } = {
             ...defaults,
             ...options
           }
@@ -43,8 +56,12 @@ export const queryHandler = {
                 order
               },
               search: {
-                title
-              }
+                title,
+                author,
+                organisations,
+                status
+              },
+              filters
             }
           }
         }
@@ -55,5 +72,5 @@ export const queryHandler = {
 
 /**
  * @import { ServerRegisterPluginObject } from '@hapi/hapi'
- * @import { QueryOptions, QueryResult } from '@defra/forms-model'
+ * @import { QueryOptions, QueryResult, FilterOptions } from '@defra/forms-model'
  */

--- a/src/plugins/query-handler/types.js
+++ b/src/plugins/query-handler/types.js
@@ -1,7 +1,7 @@
 /**
  * @template T The type of items in the array
  * @typedef {object} QueryHandlerToolkit<T>
- * @property {function(Array<T>, number, QueryOptions): QueryResult<T>} queryResponse - Creates a standardised response with pagination, sorting, and search metadata
+ * @property {function(Array<T>, number, QueryOptions, FilterOptions): QueryResult<T>} queryResponse - Creates a standardised response with pagination, sorting, and search metadata
  */
 
 /**
@@ -23,6 +23,6 @@
  */
 
 /**
- * @import { QueryOptions, QueryResult, PaginationOptions, SortingOptions, SearchOptions } from '@defra/forms-model'
+ * @import { QueryOptions, QueryResult, PaginationOptions, SortingOptions, SearchOptions, FilterOptions } from '@defra/forms-model'
  * @import { ResponseToolkit, Server } from '@hapi/hapi'
  */

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -3,7 +3,6 @@ import {
   formMetadataInputSchema,
   queryOptionsSchema
 } from '@defra/forms-model'
-import Boom from '@hapi/boom'
 
 import {
   createDraftFromLive,
@@ -17,30 +16,13 @@ import {
   updateDraftFormDefinition,
   updateFormMetadata
 } from '~/src/api/forms/service.js'
+import { getAuthor } from '~/src/helpers/get-author.js'
 import {
   createFormSchema,
   formByIdSchema,
   formBySlugSchema,
   updateFormDefinitionSchema
 } from '~/src/models/forms.js'
-
-/**
- * Get the author from the auth credentials
- * @param {UserCredentials & OidcStandardClaims} [user]
- * @returns {FormMetadataAuthor}
- */
-function getAuthor(user) {
-  if (!user || !user.oid) {
-    throw Boom.unauthorized(
-      'Failed to get the author. User is undefined or has a malformed/missing oid.'
-    )
-  }
-
-  return {
-    id: user.oid,
-    displayName: `${user.given_name} ${user.family_name}`
-  }
-}
 
 /**
  * @type {ServerRoute[]}
@@ -56,8 +38,9 @@ export default [
     async handler(request, h) {
       const { query } = request
 
-      const { forms, totalItems } = await listForms(query)
-      return h.queryResponse(forms, totalItems, query)
+      const { forms, totalItems, filters } = await listForms(query)
+
+      return h.queryResponse(forms, totalItems, query, filters)
     },
     options: {
       auth: false,


### PR DESCRIPTION
## Ticket Link
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/479076

## Description
This PR introduces:
1.  Additional search params: author (string), organisations (array of strings) and status (array of strings)
2. A meta filter object in the response, which will allow the client to parse and filter options, as it's an aggregation of the results of the db query result. 

An example response:
```
{
    "data": [
        {
          ...
        }
    ],
    "meta": {
        "pagination": {
            "page": 1,
            "perPage": 24,
            "totalItems": 1,
            "totalPages": 1
        },
        "sorting": {
            "sortBy": "updatedAt",
            "order": "desc"
        },
        "search": {
            "title": "",
            "author": "",
            "organisations": [
                "Defra"
            ],
            "status": []
        },
        "filters": {
            "authors": [
                "Ant",
                "James",
                "Mohammed",
                "Mohammed Khalid (Esynergy)",
                "Tom"
            ],
            "organisations": [
                "Animal and Plant Health Agency – APHA",
                "Centre for Environment, Fisheries and Aquaculture Science – Cefas",
                "Defra",
                "Environment Agency",
                "Forestry Commission",
                "Marine Management Organisation – MMO",
                "Natural England",
                "Rural Payments Agency – RPA",
                "Veterinary Medicines Directorate – VMD"
            ],
            "statuses": [
                "live",
                "draft"
            ]
        }
    }
}
```