### PR TITLE
Feature/466796  redesign create page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/forms-model": "^3.0.398",
+        "@defra/forms-model": "^3.0.399",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.3.12",
@@ -23,7 +23,8 @@
         "mongodb": "^6.8.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
-        "proxy-agent": "^6.5.0"
+        "proxy-agent": "^6.5.0",
+        "uuid": "^11.0.5"
       },
       "devDependencies": {
         "@babel/cli": "^7.26.4",
@@ -1735,9 +1736,9 @@
       "dev": true
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.398",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.398.tgz",
-      "integrity": "sha512-xRw5Zrbfy5v/rSZk72c8NsugfhTUYcJtlWdxsiHiBpqk086lfRM+PjYee3gJbNX/NVR0a3oTK0hGsLv+3zDevA==",
+      "version": "3.0.399",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.399.tgz",
+      "integrity": "sha512-o4GOhfS4e+sF9zHM++U8ECcTATzTbwOi0bAPxHLrk0ToJoxN45Uj6mOlRgS6CvgNtV1hEm3TGtJkUiZINV7bew==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "marked": "^15.0.6",
@@ -11886,6 +11887,19 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "dependencies": {
-    "@defra/forms-model": "^3.0.398",
+    "@defra/forms-model": "^3.0.399",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.3.12",
@@ -44,7 +44,8 @@
     "mongodb": "^6.8.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
-    "proxy-agent": "^6.5.0"
+    "proxy-agent": "^6.5.0",
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.26.4",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.sourceEncoding=UTF-8
 
 sonar.sources=src
-sonar.exclusions=**/*.test.*
+sonar.exclusions=**/*.test.*,**/__mocks__/**,**/__stubs__/**
 sonar.tests=src,test
-sonar.test.inclusions=**/*.test.*
-sonar.cpd.exclusions=**/*.test.*
+sonar.test.inclusions=**/*.test.*,**/__mocks__/**,**/__stubs__/**
+sonar.cpd.exclusions=**/*.test.*,**/__mocks__/**,**/__stubs__/**

--- a/src/api/forms/__stubs__/definition.js
+++ b/src/api/forms/__stubs__/definition.js
@@ -1,0 +1,63 @@
+import { ControllerPath, ControllerType } from '@defra/forms-model'
+
+import { empty, emptyPage } from '~/src/api/forms/templates.js'
+
+/**
+ * @param {Partial<Page>} partialPage
+ * @returns {Page}
+ */
+export function buildPage(partialPage) {
+  return /** @satisfies {Page} */ {
+    ...emptyPage(),
+    ...partialPage
+  }
+}
+
+/**
+ * Creates a page array with a summary at the end
+ * @param {Page} pages
+ * @returns {Page[]}
+ */
+export function buildPages(...pages) {
+  return /** @satisfies {Page[]} */ [
+    ...pages,
+    {
+      id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
+      title: 'Summary',
+      path: ControllerPath.Summary,
+      controller: ControllerType.Summary
+    }
+  ]
+}
+
+/**
+ * @param {Partial<PageSummary>} partialSummaryPage
+ * @returns {PageSummary}
+ */
+export function buildSummaryPage(partialSummaryPage) {
+  return /** @satisfies {PageSummary} */ {
+    id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
+    title: 'Summary',
+    path: ControllerPath.Summary,
+    controller: ControllerType.Summary,
+    ...partialSummaryPage
+  }
+}
+
+/**
+ * Builds a form definition
+ * @param {Partial<FormDefinition>} partialDefinition
+ * @returns {FormDefinition}
+ */
+export function buildDefinition(partialDefinition) {
+  const emptyDefinition = empty()
+  return /** @satisfies {FormDefinition} */ {
+    ...emptyDefinition,
+    ...partialDefinition
+  }
+}
+
+/**
+ * @import { FormDefinition, Page, PageSummary } from '@defra/forms-model'
+ * @import { WithId } from 'mongodb'
+ */

--- a/src/api/forms/repositories/form-definition-repository.test.js
+++ b/src/api/forms/repositories/form-definition-repository.test.js
@@ -1,0 +1,177 @@
+import Boom from '@hapi/boom'
+import Joi from 'joi'
+
+import { pushSummaryToEnd } from '~/src/api/forms/repositories/form-definition-repository.js'
+import { db } from '~/src/mongo.js'
+
+const mockCollection = {
+  findOne: jest.fn(),
+  updateOne: jest.fn()
+}
+
+/**
+ * @satisfies {FormMetadataAuthor}
+ */
+const author = {
+  id: 'f50ceeed-b7a4-47cf-a498-094efc99f8bc',
+  displayName: 'Enrique Chase'
+}
+
+jest.mock('~/src/mongo.js', () => {
+  let isPrepared = false
+
+  return {
+    db: {
+      collection: jest.fn().mockImplementation(() => mockCollection)
+    },
+    get client() {
+      if (!isPrepared) {
+        return undefined
+      }
+
+      return {
+        startSession: () => ({
+          endSession: jest.fn().mockResolvedValue(undefined),
+          withTransaction: jest.fn(
+            /**
+             * Mock transaction handler
+             * @param {() => Promise<void>} fn
+             */
+            async (fn) => fn()
+          )
+        })
+      }
+    },
+
+    prepareDb() {
+      isPrepared = true
+      return Promise.resolve()
+    }
+  }
+})
+
+describe('form-definition-repository', () => {
+  beforeEach(() => {
+    db.collection.mockReturnValue(mockCollection)
+  })
+  describe('pushSummaryToEnd', () => {
+    it('should not edit a live summary', async () => {
+      await expect(pushSummaryToEnd('1234', author, 'live')).rejects.toThrow(
+        Boom.badRequest('Cannot add summary page to end of a live form')
+      )
+    })
+    it('should fail if collection does not exist', async () => {
+      mockCollection.findOne.mockResolvedValue(null)
+
+      await expect(
+        pushSummaryToEnd('67ade425d6e8ab1116b0aa9a', author)
+      ).rejects.toThrow(
+        Boom.notFound(
+          `Form definition with ID '67ade425d6e8ab1116b0aa9a' not found`
+        )
+      )
+    })
+    it('should push the summary to the end if it exists but is not at the end', async () => {
+      const docMock = {
+        draft: {
+          name: 'Form with Summary at end',
+          startPage: '/form-with-summary',
+          pages: [
+            {
+              id: '1e322ebc-18ea-4b5d-846a-76bc08fc9943',
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            },
+            {
+              title: 'Test page',
+              path: '/test-page',
+              next: [],
+              components: []
+            }
+          ],
+          conditions: [],
+          sections: [],
+          lists: []
+        }
+      }
+      mockCollection.findOne.mockResolvedValue(docMock)
+
+      const summary = await pushSummaryToEnd('67ade425d6e8ab1116b0aa9a', author)
+      expect(summary).toEqual({
+        id: '1e322ebc-18ea-4b5d-846a-76bc08fc9943',
+        title: 'Summary',
+        path: '/summary',
+        controller: 'SummaryPageController'
+      })
+      expect(mockCollection.updateOne).toHaveBeenCalled()
+    })
+
+    it('should not update the document if summary page is at end', async () => {
+      const docMock = {
+        draft: {
+          name: 'Form with Summary at end',
+          startPage: '/form-with-summary',
+          pages: [
+            {
+              title: 'Test page',
+              path: '/test-page',
+              next: [],
+              components: []
+            },
+            {
+              id: '1e322ebc-18ea-4b5d-846a-76bc08fc9943',
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [],
+          lists: []
+        }
+      }
+      mockCollection.findOne.mockResolvedValue(docMock)
+
+      const summary = await pushSummaryToEnd('67ade425d6e8ab1116b0aa9a', author)
+      expect(mockCollection.updateOne).not.toHaveBeenCalled()
+      expect(summary).toEqual({
+        id: '1e322ebc-18ea-4b5d-846a-76bc08fc9943',
+        title: 'Summary',
+        path: '/summary',
+        controller: 'SummaryPageController'
+      })
+    })
+
+    it('should not update the document if no summary page exists', async () => {
+      const docMock = {
+        draft: {
+          name: 'Form with Summary at end',
+          startPage: '/form-with-summary',
+          pages: [
+            {
+              title: 'Test page',
+              path: '/test-page',
+              next: [],
+              components: []
+            }
+          ],
+          conditions: [],
+          sections: [],
+          lists: []
+        }
+      }
+      mockCollection.findOne.mockResolvedValue(docMock)
+
+      const summary = await pushSummaryToEnd('67ade425d6e8ab1116b0aa9a', author)
+      expect(mockCollection.updateOne).not.toHaveBeenCalled()
+      expect(summary).toBeUndefined()
+    })
+
+    it('should be ok', () => {
+      Joi.array()
+        .items(Joi.object({ id: Joi.string().hex().length(24).optional() }))
+        .validate([{ id: 'ee717f885e9519dd4bd094c8' }])
+    })
+  })
+})

--- a/src/api/forms/repositories/form-definition-repository.test.js
+++ b/src/api/forms/repositories/form-definition-repository.test.js
@@ -2,6 +2,7 @@ import Boom from '@hapi/boom'
 import Joi from 'joi'
 
 import { pushSummaryToEnd } from '~/src/api/forms/repositories/form-definition-repository.js'
+import { getAuthor } from '~/src/helpers/get-author.js'
 import { db } from '~/src/mongo.js'
 
 const mockCollection = {
@@ -9,13 +10,9 @@ const mockCollection = {
   updateOne: jest.fn()
 }
 
-/**
- * @satisfies {FormMetadataAuthor}
- */
-const author = {
-  id: 'f50ceeed-b7a4-47cf-a498-094efc99f8bc',
-  displayName: 'Enrique Chase'
-}
+jest.mock('~/src/helpers/get-author.js')
+
+const author = getAuthor()
 
 jest.mock('~/src/mongo.js', () => {
   let isPrepared = false

--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -24,7 +24,7 @@ export async function removeById(session, collectionName, id) {
 
 /**
  * @param {FormDefinition} definition
- * @returns {{readonly summary: PageSummary|undefined, readonly shouldPush: boolean, readonly exists: boolean}}
+ * @returns {{readonly summary: PageSummary|undefined, readonly shouldPushSummary: boolean, readonly summaryExists: boolean}}
  */
 export function summaryHelper(definition) {
   const lastIndex = definition.pages.length - 1
@@ -33,10 +33,10 @@ export function summaryHelper(definition) {
   )
 
   return {
-    get shouldPush() {
+    get shouldPushSummary() {
       return summaryIdx !== lastIndex
     },
-    get exists() {
+    get summaryExists() {
       return summaryIdx >= 0
     },
     get summary() {

--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -1,3 +1,4 @@
+import { ControllerType } from '@defra/forms-model'
 import { ObjectId } from 'mongodb'
 
 import { db } from '~/src/mongo.js'
@@ -22,5 +23,29 @@ export async function removeById(session, collectionName, id) {
 }
 
 /**
+ * @param {FormDefinition} definition
+ * @returns {{readonly summary: PageSummary|undefined, readonly shouldPush: boolean, readonly exists: boolean}}
+ */
+export function summaryHelper(definition) {
+  const lastIndex = definition.pages.length - 1
+  const summaryIdx = definition.pages.findIndex(
+    (page) => page.controller === ControllerType.Summary
+  )
+
+  return {
+    get shouldPush() {
+      return summaryIdx !== lastIndex
+    },
+    get exists() {
+      return summaryIdx >= 0
+    },
+    get summary() {
+      return definition.pages[summaryIdx]
+    }
+  }
+}
+
+/**
+ * @import { FormDefinition, Page, PageSummary } from '@defra/forms-model'
  * @import { ClientSession } from 'mongodb'
  */

--- a/src/api/forms/repositories/helpers.test.js
+++ b/src/api/forms/repositories/helpers.test.js
@@ -6,7 +6,7 @@ import {
 import { summaryHelper } from '~/src/api/forms/repositories/helpers.js'
 
 describe('repository helpers', () => {
-  describe('shouldPushSummaryToEnd', () => {
+  describe('summaryHelper', () => {
     const summary = buildSummaryPage({})
 
     it('should push the summary to the end if it not in the correct place', () => {
@@ -14,8 +14,8 @@ describe('repository helpers', () => {
         pages: [summary, buildPage({})]
       })
       expect(summaryHelper(definition)).toEqual({
-        shouldPush: true,
-        exists: true,
+        shouldPushSummary: true,
+        summaryExists: true,
         summary
       })
     })
@@ -25,19 +25,19 @@ describe('repository helpers', () => {
         pages: [buildPage({}), summary]
       })
       expect(summaryHelper(definition)).toEqual({
-        shouldPush: false,
-        exists: true,
+        shouldPushSummary: false,
+        summaryExists: true,
         summary
       })
     })
 
-    it('should not push summary to the end if no summary exists', () => {
+    it('should not push summary to the end if no summary summaryExists', () => {
       const definition = buildDefinition({
         pages: []
       })
       expect(summaryHelper(definition)).toEqual({
-        shouldPush: false,
-        exists: false,
+        shouldPushSummary: false,
+        summaryExists: false,
         summary: undefined
       })
     })

--- a/src/api/forms/repositories/helpers.test.js
+++ b/src/api/forms/repositories/helpers.test.js
@@ -1,0 +1,45 @@
+import {
+  buildDefinition,
+  buildPage,
+  buildSummaryPage
+} from '~/src/api/forms/__stubs__/definition.js'
+import { summaryHelper } from '~/src/api/forms/repositories/helpers.js'
+
+describe('repository helpers', () => {
+  describe('shouldPushSummaryToEnd', () => {
+    const summary = buildSummaryPage({})
+
+    it('should push the summary to the end if it not in the correct place', () => {
+      const definition = buildDefinition({
+        pages: [summary, buildPage({})]
+      })
+      expect(summaryHelper(definition)).toEqual({
+        shouldPush: true,
+        exists: true,
+        summary
+      })
+    })
+
+    it('should not push summary to the end if it is in the correct place', () => {
+      const definition = buildDefinition({
+        pages: [buildPage({}), summary]
+      })
+      expect(summaryHelper(definition)).toEqual({
+        shouldPush: false,
+        exists: true,
+        summary
+      })
+    })
+
+    it('should not push summary to the end if no summary exists', () => {
+      const definition = buildDefinition({
+        pages: []
+      })
+      expect(summaryHelper(definition)).toEqual({
+        shouldPush: false,
+        exists: false,
+        summary: undefined
+      })
+    })
+  })
+})

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -519,15 +519,15 @@ export async function removeForm(formId) {
  * @param {string} formId
  * @param {Page} newPage
  * @param {FormMetadataAuthor} author
- * @param {string} [state]
  */
-export async function createPage(formId, newPage, author, state = 'draft') {
+export async function createPageOnDraftDefinition(formId, newPage, author) {
   logger.info(`Creating new page for form with ID ${formId}`)
 
   const session = client.startSession()
+
   try {
     await session.withTransaction(async () => {
-      await formDefinition.addPage(formId, newPage, session, state)
+      await formDefinition.addPage(formId, newPage, session, 'draft')
 
       // Update the form with the new draft state
       await formMetadata.update(
@@ -541,7 +541,9 @@ export async function createPage(formId, newPage, author, state = 'draft') {
   }
 
   logger.info(`Created new page for form with ID ${formId}`)
-  return /** @satisfies {Page[]} */ []
+
+  const { pages } = await getFormDefinition(formId, 'draft')
+  return /** @satisfies {Page[]} */ pages
 }
 
 /**

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -519,6 +519,7 @@ export async function removeForm(formId) {
  * @param {string} formId
  * @param {Page} newPage
  * @param {FormMetadataAuthor} author
+ * @returns {Promise<Page[]>}
  */
 export async function createPageOnDraftDefinition(formId, newPage, author) {
   logger.info(`Creating new page for form with ID ${formId}`)

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -522,7 +522,7 @@ describe('Forms service', () => {
       ).rejects.toThrow(error)
     })
 
-    it('should throw an error when title already summaryExists', async () => {
+    it('should throw an error when title already exists', async () => {
       const duplicateError = new MongoServerError({
         message: 'duplicate key error',
         code: 11000
@@ -1143,7 +1143,7 @@ describe('Forms service', () => {
   })
 
   describe('getFormBySlug', () => {
-    it('should return form metadata when form summaryExists', async () => {
+    it('should return form metadata when form exists', async () => {
       jest
         .mocked(formMetadata.getBySlug)
         .mockResolvedValue(formMetadataDocument)

--- a/src/api/forms/templates.js
+++ b/src/api/forms/templates.js
@@ -1,8 +1,4 @@
-import {
-  ComponentType,
-  ControllerPath,
-  ControllerType
-} from '@defra/forms-model'
+import { ControllerPath, ControllerType } from '@defra/forms-model'
 
 /**
  * Function to return an empty form
@@ -12,22 +8,6 @@ export function empty() {
     name: '',
     startPage: '/page-one',
     pages: [
-      {
-        path: '/page-one',
-        title: 'Page one',
-        section: 'section',
-        components: [
-          {
-            type: ComponentType.TextField,
-            name: 'textField',
-            title: 'This is your first field',
-            hint: 'Help text',
-            options: {},
-            schema: {}
-          }
-        ],
-        next: [{ path: ControllerPath.Summary }]
-      },
       {
         title: 'Summary',
         path: ControllerPath.Summary,

--- a/src/api/forms/templates.js
+++ b/src/api/forms/templates.js
@@ -6,7 +6,7 @@ import { ControllerPath, ControllerType } from '@defra/forms-model'
 export function empty() {
   return /** @satisfies {FormDefinition} */ ({
     name: '',
-    startPage: '',
+    startPage: '/page-one',
     pages: [
       {
         id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
@@ -27,5 +27,18 @@ export function empty() {
 }
 
 /**
- * @import { FormDefinition } from '@defra/forms-model'
+ *
+ * @returns {Page}
+ */
+export function emptyPage() {
+  return /** @satisfies {Page} */ {
+    title: 'Page One',
+    path: '/page-one',
+    next: [],
+    components: []
+  }
+}
+
+/**
+ * @import { FormDefinition, Page } from '@defra/forms-model'
  */

--- a/src/api/forms/templates.js
+++ b/src/api/forms/templates.js
@@ -6,9 +6,10 @@ import { ControllerPath, ControllerType } from '@defra/forms-model'
 export function empty() {
   return /** @satisfies {FormDefinition} */ ({
     name: '',
-    startPage: '/page-one',
+    startPage: '',
     pages: [
       {
+        id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
         title: 'Summary',
         path: ControllerPath.Summary,
         controller: ControllerType.Summary

--- a/src/helpers/__mocks__/get-author.js
+++ b/src/helpers/__mocks__/get-author.js
@@ -1,0 +1,17 @@
+/**
+ * Get the author from the auth credentials
+ * @param {UserCredentials & OidcStandardClaims} [user]
+ * @returns {FormMetadataAuthor}
+ */
+export function getAuthor() {
+  return {
+    id: 'f50ceeed-b7a4-47cf-a498-094efc99f8bc',
+    displayName: 'Enrique Chase'
+  }
+}
+
+/**
+ * @import { FormMetadataAuthor } from '@defra/forms-model'
+ * @import { UserCredentials } from '@hapi/hapi'
+ * @import { OidcStandardClaims } from 'oidc-client-ts'
+ */

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -1,6 +1,7 @@
 import {
   formMetadataInputKeys,
   formMetadataInputSchema,
+  pageSchema,
   queryOptionsSchema
 } from '@defra/forms-model'
 
@@ -8,6 +9,7 @@ import {
   createDraftFromLive,
   createForm,
   createLiveFromDraft,
+  createPageOnDraftDefinition,
   getForm,
   getFormBySlug,
   getFormDefinition,
@@ -202,6 +204,22 @@ export default [
     options: {
       validate: {
         payload: updateFormDefinitionSchema
+      }
+    }
+  },
+  {
+    method: 'POST',
+    path: '/forms/{id}/definition/draft/pages',
+    async handler(request) {
+      const { auth, params, payload } = request
+      const author = getAuthor(auth.credentials.user)
+
+      return createPageOnDraftDefinition(params.id, payload, author)
+    },
+    options: {
+      validate: {
+        params: formByIdSchema,
+        payload: pageSchema
       }
     }
   },


### PR DESCRIPTION
This is a new add page endpoint:

/forms/:id/definition/draft/pages

- Returns a full list of pages on the definition.
- Adds the summary to the end if it is not already
- Adds the new page before the summary if it exists
- New helper method for checking whether summary needs resorting/exists

Will need the new model in other PR.