### PR TITLE
Feature/466796  redesign create page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/forms-model": "^3.0.400",
+        "@defra/forms-model": "^3.0.402",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.3.12",
@@ -1736,9 +1736,9 @@
       "dev": true
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.400",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.400.tgz",
-      "integrity": "sha512-foeV+rY110TlQRk8V1ppm9+N4AlyBiyJV1hURCZDlnCZcgGQqgQNtkkm/9U8WruyrSRF2X6uPfJIUJQmdDx43w==",
+      "version": "3.0.402",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.402.tgz",
+      "integrity": "sha512-2A8wPEGiCkQon9NoPSBUvkHayi+p3nlounVz+doSKE3AelnPZ59ObfmyJ4HsE32w2unQUj8cbHwKG4p0QWwpnw==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "marked": "^15.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "dependencies": {
-    "@defra/forms-model": "^3.0.402",
+    "@defra/forms-model": "^3.0.403",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.3.12",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "dependencies": {
-    "@defra/forms-model": "^3.0.400",
+    "@defra/forms-model": "^3.0.402",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.3.12",

--- a/src/api/forms/__stubs__/definition.js
+++ b/src/api/forms/__stubs__/definition.js
@@ -61,7 +61,7 @@ export function buildDefinition(partialDefinition) {
  * @param {Partial<TextFieldComponent>} partialTextField
  * @returns {TextFieldComponent}
  */
-export function buildTextFieldComponent(partialTextField) {
+export function buildTextFieldComponent(partialTextField = {}) {
   return /** @satisfies {TextFieldComponent} */ {
     name: 'TextField',
     title: 'Text field',

--- a/src/api/forms/repositories/form-definition-repository.js
+++ b/src/api/forms/repositories/form-definition-repository.js
@@ -173,6 +173,38 @@ export async function updateName(formId, name, session, state = DRAFT) {
 }
 
 /**
+ * Updates the name of a draft form definition
+ * @param {string} formId - the ID of the form
+ * @param {Partial<Page>} matchCriteria - new name for the form
+ * @param {ClientSession} session
+ * @param {'draft' | 'live'} [state] - state of the form to update
+ */
+export async function removeMatchingPages(
+  formId,
+  matchCriteria,
+  session,
+  state = DRAFT
+) {
+  if (state === 'live') {
+    throw Boom.badRequest(`Cannot remove page on live form ID ${formId}`)
+  }
+  logger.info(`Removing page on ${formId}`)
+
+  const coll = /** @satisfies {Collection<{draft: FormDefinition}>} */ (
+    db.collection(DEFINITION_COLLECTION_NAME)
+  )
+  await coll.updateOne(
+    { _id: new ObjectId(formId) },
+    {
+      $pull: { 'draft.pages': matchCriteria } // Removes all Summary pages
+    },
+    { session }
+  )
+
+  logger.info(`Removed page on ${formId}`)
+}
+
+/**
  * Pushes the summary page to the last page
  * @param {string} formId - the ID of the form
  * @param {ClientSession} session

--- a/src/api/forms/repositories/form-definition-repository.js
+++ b/src/api/forms/repositories/form-definition-repository.js
@@ -178,7 +178,7 @@ export async function updateName(formId, name, session, state = DRAFT) {
 /**
  * Removes pages that match the matchCriteria
  * @param {string} formId - the ID of the form
- * @param {Partial<Page>} matchCriteria - new name for the form
+ * @param {{ controller: ControllerType.Summary }} matchCriteria - new name for the form
  * @param {ClientSession} session
  * @param {State} [state] - state of the form to update
  */
@@ -375,6 +375,6 @@ export async function updateComponent(
 }
 
 /**
- * @import { FormDefinition, Page, PageSummary, ComponentDef } from '@defra/forms-model'
+ * @import { FormDefinition, Page, PageSummary, ComponentDef, ControllerType } from '@defra/forms-model'
  * @import { ClientSession, Collection, Document, InferIdType } from 'mongodb'
  */

--- a/src/api/forms/repositories/form-definition-repository.js
+++ b/src/api/forms/repositories/form-definition-repository.js
@@ -267,6 +267,34 @@ export async function addPage(formId, page, session, state = DRAFT) {
 }
 
 /**
+ * @param {string} formId
+ * @param {string} pageId
+ * @param {Page} page
+ * @param {ClientSession} session
+ * @param {'live' | 'draft'} [state]
+ * @returns {Promise<void>}
+ */
+export async function updatePage(formId, pageId, page, session, state = DRAFT) {
+  if (state === 'live') {
+    throw Boom.badRequest(`Cannot update page on a live form - ${formId}`)
+  }
+
+  logger.info(`Updating page ID ${pageId} on form ID ${formId}`)
+
+  const coll = /** @satisfies {Collection<{draft: FormDefinition}>} */ (
+    db.collection(DEFINITION_COLLECTION_NAME)
+  )
+
+  await coll.updateOne(
+    { _id: new ObjectId(formId), 'draft.pages.id': pageId },
+    { $set: { 'draft.pages.$': page } },
+    { session }
+  )
+
+  logger.info(`Updated page ID ${pageId} on form ID ${formId}`)
+}
+
+/**
  * @import { FormDefinition, Page, PageSummary } from '@defra/forms-model'
  * @import { ClientSession, Collection } from 'mongodb'
  */

--- a/src/api/forms/repositories/form-definition-repository.js
+++ b/src/api/forms/repositories/form-definition-repository.js
@@ -169,7 +169,7 @@ export async function updateName(formId, name, session, state = DRAFT) {
 }
 
 /**
- * Updates the name of a draft form definition
+ * Removes pages that match the matchCriteria
  * @param {string} formId - the ID of the form
  * @param {Partial<Page>} matchCriteria - new name for the form
  * @param {ClientSession} session
@@ -192,7 +192,7 @@ export async function removeMatchingPages(
   await coll.updateOne(
     { _id: new ObjectId(formId) },
     {
-      $pull: { 'draft.pages': matchCriteria } // Removes all Summary pages
+      $pull: { 'draft.pages': matchCriteria }
     },
     { session }
   )
@@ -201,6 +201,7 @@ export async function removeMatchingPages(
 }
 
 /**
+ * Add a page at the position number - defaults to the last page
  * @param {string} formId - the ID of the form
  * @param {Page} page - new name for the form
  * @param {ClientSession} session
@@ -235,6 +236,7 @@ export async function addPageAtPosition(
 }
 
 /**
+ * Updates a page with specific page id on forms
  * @param {string} formId
  * @param {string} pageId
  * @param {Page} page
@@ -263,6 +265,7 @@ export async function updatePage(formId, pageId, page, session, state = DRAFT) {
 }
 
 /**
+ * Adds a new component to the end of a page->components array
  * @param {string} formId
  * @param {string} pageId
  * @param {ComponentDef[]} components

--- a/src/api/forms/repositories/form-definition-repository.js
+++ b/src/api/forms/repositories/form-definition-repository.js
@@ -1,11 +1,7 @@
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
-import { v4 as uuidv4 } from 'uuid'
 
-import {
-  removeById,
-  summaryHelper
-} from '~/src/api/forms/repositories/helpers.js'
+import { removeById } from '~/src/api/forms/repositories/helpers.js'
 import { createLogger } from '~/src/helpers/logging/logger.js'
 import { DEFINITION_COLLECTION_NAME, db } from '~/src/mongo.js'
 
@@ -209,7 +205,6 @@ export async function removeMatchingPages(
  * @param {Page} page - new name for the form
  * @param {ClientSession} session
  * @param {{position?: number; state?: 'live' | 'draft' }} options
- * @returns {Promise<void>}
  */
 export async function addPageAtPosition(
   formId,
@@ -237,100 +232,6 @@ export async function addPageAtPosition(
   )
 
   logger.info(`Added page on Form ID ${formId}`)
-}
-
-/**
- * Pushes the summary page to the last page
- * @param {string} formId - the ID of the form
- * @param {ClientSession} session
- * @param {'draft' | 'live'} [state] - state of the form to update
- * @returns {Promise<undefined | PageSummary>}
- */
-export async function pushSummaryToEnd(formId, session, state = DRAFT) {
-  if (state === 'live') {
-    throw Boom.badRequest('Cannot add summary page to end of a live form')
-  }
-  logger.info(`Checking position of summary on ${formId}`)
-
-  const definition = await get(formId, state)
-
-  const { shouldRepositionSummary, summary } = summaryHelper(definition)
-
-  if (!shouldRepositionSummary) {
-    logger.info(`Position of summary on ${formId} correct`)
-    return summary
-  }
-
-  logger.info(`Updating position of summary on ${formId}`)
-
-  const coll = /** @satisfies {Collection<{draft: FormDefinition}>} */ (
-    db.collection(DEFINITION_COLLECTION_NAME)
-  )
-
-  await coll.updateOne(
-    { _id: new ObjectId(formId) },
-    {
-      $pull: { 'draft.pages': { controller: 'SummaryPageController' } } // Removes all Summary pages
-    },
-    { session }
-  )
-  await coll.updateOne(
-    { _id: new ObjectId(formId) },
-    {
-      $push: { 'draft.pages': summary } // Adds the summary page back
-    },
-    { session }
-  )
-  logger.info(`Updated position of summary on ${formId}`)
-
-  return summary
-}
-
-/**
- * @param {string} formId
- * @param {Page} page
- * @param {ClientSession} session
- * @param {'draft' | 'live'} [state]
- * @returns {Promise<Page>}
- */
-export async function addPage(formId, page, session, state = DRAFT) {
-  logger.info(`Creating new page for form with ID ${formId}`)
-
-  /**
-   * @type {FormDefinition}
-   */
-  const definition = await get(formId, state)
-
-  const { shouldRepositionSummary, summaryExists } = summaryHelper(definition)
-
-  if (shouldRepositionSummary) {
-    await pushSummaryToEnd(formId, session, state)
-  }
-
-  const $position = summaryExists ? -1 : definition.pages.length
-
-  const coll = /** @satisfies {Collection<{draft: FormDefinition}>} */ (
-    db.collection(DEFINITION_COLLECTION_NAME)
-  )
-
-  const pageToAdd = /** @type {Page} */ ({
-    id: uuidv4(),
-    ...page
-  })
-
-  await coll.updateOne(
-    { _id: new ObjectId(formId) },
-    {
-      $push: {
-        'draft.pages': { $each: [pageToAdd], $position }
-      }
-    },
-    { session }
-  )
-
-  logger.info(`Created new page for form with ID ${formId}`)
-
-  return pageToAdd
 }
 
 /**

--- a/src/api/forms/repositories/form-definition-repository.js
+++ b/src/api/forms/repositories/form-definition-repository.js
@@ -96,6 +96,7 @@ export async function createDraftFromLive(id, session) {
  * Retrieves the form definition for a given form ID
  * @param {string} formId - the ID of the form
  * @param {State} state - the form state
+ * @returns {Promise<FormDefinition>}
  */
 export async function get(formId, state = DRAFT) {
   logger.info(`Getting form definition (${state}) for form ID ${formId}`)

--- a/src/api/forms/repositories/form-definition-repository.test.js
+++ b/src/api/forms/repositories/form-definition-repository.test.js
@@ -116,7 +116,7 @@ describe('form-definition-repository', () => {
       await addPageAtPosition(formId, page, mockSession, { position: -1 })
 
       const [filter, update] = mockCollection.updateOne.mock.calls[0]
-      expect(filter).toMatchObject({
+      expect(filter).toEqual({
         _id: new ObjectId(formId)
       })
       expect(update).toMatchObject({
@@ -128,12 +128,12 @@ describe('form-definition-repository', () => {
       await addPageAtPosition(formId, page, mockSession, {})
 
       const [filter, update] = mockCollection.updateOne.mock.calls[0]
-      expect(filter).toMatchObject({
+      expect(filter).toEqual({
         _id: new ObjectId(formId)
       })
-      expect(update).toMatchObject({
+      expect(update).toEqual({
         $push: {
-          'draft.pages': { $each: [page], $position: Number.MAX_SAFE_INTEGER }
+          'draft.pages': { $each: [page] }
         }
       })
     })

--- a/src/api/forms/repositories/form-definition-repository.test.js
+++ b/src/api/forms/repositories/form-definition-repository.test.js
@@ -3,17 +3,13 @@ import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 
 import {
-  buildDefinition,
   buildQuestionPage,
-  buildSummaryPage,
   buildTextFieldComponent
 } from '~/src/api/forms/__stubs__/definition.js'
 import { buildMockCollection } from '~/src/api/forms/__stubs__/mongo.js'
 import {
   addComponents,
-  addPage,
   addPageAtPosition,
-  pushSummaryToEnd,
   removeMatchingPages,
   updatePage
 } from '~/src/api/forms/repositories/form-definition-repository.js'
@@ -140,179 +136,6 @@ describe('form-definition-repository', () => {
           'draft.pages': { $each: [page], $position: Number.MAX_SAFE_INTEGER }
         }
       })
-    })
-  })
-
-  describe('pushSummaryToEnd', () => {
-    const summary = {
-      id: '1e322ebc-18ea-4b5d-846a-76bc08fc9943',
-      title: 'Summary',
-      path: '/summary',
-      controller: 'SummaryPageController'
-    }
-
-    it('should not edit a live summary', async () => {
-      await expect(
-        pushSummaryToEnd('1234', mockSession, 'live')
-      ).rejects.toThrow(
-        Boom.badRequest('Cannot add summary page to end of a live form')
-      )
-    })
-    it('should fail if collection does not exist', async () => {
-      mockCollection.findOne.mockResolvedValue(null)
-
-      await expect(
-        pushSummaryToEnd('67ade425d6e8ab1116b0aa9a', mockSession)
-      ).rejects.toThrow(
-        Boom.notFound(
-          `Form definition with ID '67ade425d6e8ab1116b0aa9a' not found`
-        )
-      )
-    })
-    it('should push the summary to the end if it summaryExists but is not at the end', async () => {
-      const docMock = {
-        draft: {
-          name: 'Form with Summary at end',
-          startPage: '/form-with-summary',
-          pages: [
-            summary,
-            {
-              title: 'Test page',
-              path: '/test-page',
-              next: [],
-              components: []
-            }
-          ],
-          conditions: [],
-          sections: [],
-          lists: []
-        }
-      }
-      mockCollection.findOne.mockResolvedValue(docMock)
-
-      const summaryResult = await pushSummaryToEnd(
-        '67ade425d6e8ab1116b0aa9a',
-        mockSession
-      )
-
-      expect(summaryResult).toEqual(summary)
-      expect(mockCollection.updateOne).toHaveBeenNthCalledWith(
-        1,
-        expect.anything(),
-        {
-          $pull: { 'draft.pages': { controller: 'SummaryPageController' } }
-        },
-        expect.anything()
-      )
-      expect(mockCollection.updateOne).toHaveBeenNthCalledWith(
-        2,
-        expect.anything(),
-        {
-          $push: { 'draft.pages': summary } // Adds the summary page back
-        },
-        expect.anything()
-      )
-    })
-
-    it('should not update the document if summary page is at end', async () => {
-      const docMock = {
-        draft: {
-          name: 'Form with Summary at end',
-          startPage: '/form-with-summary',
-          pages: [
-            {
-              title: 'Test page',
-              path: '/test-page',
-              next: [],
-              components: []
-            },
-            summary
-          ],
-          conditions: [],
-          sections: [],
-          lists: []
-        }
-      }
-      mockCollection.findOne.mockResolvedValue(docMock)
-
-      const summaryResult = await pushSummaryToEnd(
-        '67ade425d6e8ab1116b0aa9a',
-        mockSession
-      )
-      expect(mockCollection.updateOne).not.toHaveBeenCalled()
-      expect(summaryResult).toEqual({
-        id: '1e322ebc-18ea-4b5d-846a-76bc08fc9943',
-        title: 'Summary',
-        path: '/summary',
-        controller: 'SummaryPageController'
-      })
-    })
-
-    it('should not update the document if no summary page summaryExists', async () => {
-      const docMock = {
-        draft: {
-          name: 'Form with Summary at end',
-          startPage: '/form-with-summary',
-          pages: [
-            {
-              title: 'Test page',
-              path: '/test-page',
-              next: [],
-              components: []
-            }
-          ],
-          conditions: [],
-          sections: [],
-          lists: []
-        }
-      }
-      mockCollection.findOne.mockResolvedValue(docMock)
-
-      const summary = await pushSummaryToEnd(
-        '67ade425d6e8ab1116b0aa9a',
-        mockSession
-      )
-      expect(mockCollection.updateOne).not.toHaveBeenCalled()
-      expect(summary).toBeUndefined()
-    })
-  })
-
-  describe('addPage', () => {
-    const pageToAdd = buildQuestionPage()
-    const summaryPage = buildSummaryPage({})
-
-    it('should add a page if no summary page summaryExists', async () => {
-      mockCollection.findOne.mockResolvedValue({
-        draft: buildDefinition({
-          pages: []
-        })
-      })
-      const page = await addPage(formId, pageToAdd, mockSession)
-      expect(mockCollection.updateOne).toHaveBeenCalledTimes(1)
-      expect(page).toMatchObject({
-        ...pageToAdd,
-        id: expect.any(String)
-      })
-    })
-
-    it('should add a page if summary page is last page', async () => {
-      mockCollection.findOne.mockResolvedValue({
-        draft: buildDefinition({})
-      })
-      await addPage(formId, pageToAdd, mockSession)
-      expect(mockCollection.updateOne).toHaveBeenCalledTimes(1)
-    })
-
-    it('should add a page and push summary to end if summary page summaryExists and is not last page', async () => {
-      const pageOne = buildQuestionPage({})
-
-      mockCollection.findOne.mockResolvedValue({
-        draft: buildDefinition({
-          pages: [summaryPage, pageOne]
-        })
-      })
-      await addPage(formId, pageToAdd, mockSession)
-      expect(mockCollection.updateOne).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/src/api/forms/repositories/form-definition-repository.test.js
+++ b/src/api/forms/repositories/form-definition-repository.test.js
@@ -177,7 +177,9 @@ describe('form-definition-repository', () => {
 
     it('should fail if form is live', async () => {
       await expect(
-        addComponents(formId, pageId, [component], mockSession, 'live')
+        addComponents(formId, pageId, [component], mockSession, {
+          state: 'live'
+        })
       ).rejects.toThrow(
         Boom.badRequest(
           'Cannot add component to a live form - 1eabd1437567fe1b26708bbb'
@@ -193,10 +195,30 @@ describe('form-definition-repository', () => {
         _id: new ObjectId(formId),
         'draft.pages.id': pageId
       })
-      expect(update).toMatchObject({
+      expect(update).toEqual({
         $push: {
           'draft.pages.$.components': {
             $each: [component]
+          }
+        }
+      })
+    })
+
+    it('should add a component to a page a position x', async () => {
+      await addComponents(formId, pageId, [component], mockSession, {
+        position: 0
+      })
+      const [filter, update] = mockCollection.updateOne.mock.calls[0]
+
+      expect(filter).toEqual({
+        _id: new ObjectId(formId),
+        'draft.pages.id': pageId
+      })
+      expect(update).toEqual({
+        $push: {
+          'draft.pages.$.components': {
+            $each: [component],
+            $position: 0
           }
         }
       })

--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -1,4 +1,5 @@
 import { ControllerType } from '@defra/forms-model'
+import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 
 import { db } from '~/src/mongo.js'
@@ -52,6 +53,17 @@ export function summaryHelper(definition) {
  */
 export function findPage(definition, pageId) {
   return definition.pages.find((page) => page.id === pageId)
+}
+
+/**
+ * @param {FormDefinition} formDraftDefinition
+ * @param {string} path
+ * @param {string} message
+ */
+export const uniquePathGate = (formDraftDefinition, path, message) => {
+  if (formDraftDefinition.pages.some((page) => page.path === path)) {
+    throw Boom.conflict(message)
+  }
 }
 /**
  * @import { FormDefinition, Page, PageSummary } from '@defra/forms-model'

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -10,7 +10,10 @@ import {
 import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/repositories/form-metadata-repository.js'
-import { findPage } from '~/src/api/forms/repositories/helpers.js'
+import {
+  findPage,
+  uniquePathGate
+} from '~/src/api/forms/repositories/helpers.js'
 import * as formTemplates from '~/src/api/forms/templates.js'
 import { createLogger } from '~/src/helpers/logging/logger.js'
 import { client } from '~/src/mongo.js'
@@ -515,6 +518,7 @@ export async function removeForm(formId) {
 
   logger.info(`Removed form with ID ${formId}`)
 }
+
 // TODO: refactor business logic into service layer
 /**
  * Adds a new page to a draft definition
@@ -530,9 +534,11 @@ export async function createPageOnDraftDefinition(formId, newPage, author) {
   /** @type {FormDefinition} */
   const formDraftDefinition = await getFormDefinition(formId, DRAFT)
 
-  if (formDraftDefinition.pages.some((page) => page.path === newPage.path)) {
-    throw Boom.conflict(`Duplicate page path on Form ID ${formId}`)
-  }
+  uniquePathGate(
+    formDraftDefinition,
+    newPage.path,
+    `Duplicate page path on Form ID ${formId}`
+  )
 
   /** @type {Page | undefined} */
   let page

--- a/src/api/forms/service.js
+++ b/src/api/forms/service.js
@@ -525,7 +525,7 @@ export async function removeForm(formId) {
 }
 
 /**
- * Pipeline
+ * Repositions the summary page if it's not the last index of pages
  * @param {string} formId
  * @param {FormDefinition} definition
  * @param {FormMetadataAuthor} author
@@ -585,6 +585,7 @@ export async function repositionSummaryPipeline(formId, definition, author) {
 }
 
 /**
+ * Adds an id to a page
  * @param {Page} pageWithoutId
  * @returns {Page}
  */
@@ -594,7 +595,7 @@ const createPageWithId = (pageWithoutId) => ({
 })
 
 /**
- * Adds a new page to a draft definition
+ * Adds a new page to a draft definition and calls repositionSummaryPipeline is summary exists
  * @param {string} formId
  * @param {Page} newPage
  * @param {FormMetadataAuthor} author
@@ -653,6 +654,7 @@ export async function createPageOnDraftDefinition(formId, newPage, author) {
 }
 
 /**
+ * Adds id to a component
  * @param {ComponentDef} component
  * @returns {ComponentDef}
  */
@@ -662,6 +664,7 @@ const addIdToComponent = (component) => ({
 })
 
 /**
+ * Adds a component to the end of page components
  * @param {string} formId
  * @param {string} pageId
  * @param {ComponentDef[]} components

--- a/src/api/forms/service.test.js
+++ b/src/api/forms/service.test.js
@@ -1236,7 +1236,8 @@ describe('Forms service', () => {
       jest.mocked(formMetadata.get).mockResolvedValueOnce(formMetadataDocument)
 
       const formDefinitionPageCustomisedTitle = buildQuestionPage({
-        title: 'A new form page'
+        title: 'A new form page',
+        path: '/a-new-form-page'
       })
       const expectedPage = buildQuestionPage({
         ...formDefinitionPageCustomisedTitle,
@@ -1253,6 +1254,7 @@ describe('Forms service', () => {
         pages: expectedPages
       })
 
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(definition)
       jest.mocked(formDefinition.get).mockResolvedValueOnce(newDefinition)
 
       const dbMetadataSpy = jest.spyOn(formMetadata, 'update')
@@ -1282,9 +1284,28 @@ describe('Forms service', () => {
       expect(page).toEqual(expectedPage)
     })
 
+    it('should fail if path is duplicate', async () => {
+      const pageOne = buildQuestionPage({
+        path: '/page-one'
+      })
+      const pageOneDuplicate = buildQuestionPage({
+        title: 'Page One Duplicate',
+        path: '/page-one'
+      })
+      const definition1 = buildDefinition({
+        ...definition,
+        pages: [pageOne]
+      })
+
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(definition1)
+
+      await expect(
+        createPageOnDraftDefinition('123', pageOneDuplicate, author)
+      ).rejects.toThrow(Boom.conflict('Duplicate page path on Form ID 123'))
+    })
     it('should fail if no draft definition exists', async () => {
       jest
-        .mocked(formDefinition.addPage)
+        .mocked(formDefinition.get)
         .mockRejectedValueOnce(Boom.notFound('Error'))
       const dbMetadataSpy = jest.spyOn(formMetadata, 'update')
 

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -4,7 +4,7 @@
  * @typedef {Request<{ Server: { db: Db }, Params: FormBySlugInput }>} RequestFormBySlug
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: FormDefinition }>} RequestFormDefinition
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: Page }>} RequestPage
- * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput & {pageId: string}, Payload: ComponentDef }>} RequestComponent
+ * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput & {pageId: string}, Payload: ComponentDef; Query: {prepend?: boolean} }>} RequestComponent
  * @typedef {Request<{ Server: { db: Db }, Payload: FormMetadataInput }>} RequestFormMetadataCreate
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: Partial<FormMetadataInput> }>} RequestFormMetadataUpdateById
  * @typedef {Request<{ Server: { db: Db }, Query: QueryOptions }>} RequestListForms

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -4,6 +4,7 @@
  * @typedef {Request<{ Server: { db: Db }, Params: FormBySlugInput }>} RequestFormBySlug
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: FormDefinition }>} RequestFormDefinition
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: Page }>} RequestPage
+ * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput & {pageId: string}, Payload: ComponentDef }>} RequestComponent
  * @typedef {Request<{ Server: { db: Db }, Payload: FormMetadataInput }>} RequestFormMetadataCreate
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: Partial<FormMetadataInput> }>} RequestFormMetadataUpdateById
  * @typedef {Request<{ Server: { db: Db }, Query: QueryOptions }>} RequestListForms
@@ -14,7 +15,7 @@
  */
 
 /**
- * @import { FormByIdInput, FormBySlugInput, FormDefinition, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, QueryOptions, Page } from '@defra/forms-model'
+ * @import { FormByIdInput, FormBySlugInput, FormDefinition, FormMetadataAuthor, FormMetadataDocument, FormMetadataInput, QueryOptions, Page, ComponentDef } from '@defra/forms-model'
  * @import { Request } from '@hapi/hapi'
  * @import { Db } from 'mongodb'
  */

--- a/src/models/forms.js
+++ b/src/models/forms.js
@@ -20,6 +20,10 @@ export const pageByIdSchema = Joi.object()
   })
   .required()
 
+export const prependQuerySchema = Joi.object().keys({
+  prepend: Joi.boolean().default(false)
+})
+
 // Retrieve form by slug schema
 export const formBySlugSchema = Joi.object()
   .keys({

--- a/src/models/forms.js
+++ b/src/models/forms.js
@@ -13,6 +13,13 @@ export const formByIdSchema = Joi.object()
   })
   .required()
 
+export const pageByIdSchema = Joi.object()
+  .keys({
+    id: idSchema,
+    pageId: Joi.string().uuid().required()
+  })
+  .required()
+
 // Retrieve form by slug schema
 export const formBySlugSchema = Joi.object()
   .keys({

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -26,6 +26,7 @@ import {
   formByIdSchema,
   formBySlugSchema,
   pageByIdSchema,
+  prependQuerySchema,
   updateFormDefinitionSchema
 } from '~/src/models/forms.js'
 
@@ -235,14 +236,17 @@ export default [
      * @param {RequestComponent} request
      */
     async handler(request) {
-      const { auth, params, payload } = request
+      const { auth, params, payload, query } = request
       const { id, pageId } = params
+      const { prepend } = query
+
       const author = getAuthor(auth.credentials.user)
       const [component] = await createComponentOnDraftDefinition(
         id,
         pageId,
         [payload],
-        author
+        author,
+        prepend
       )
 
       return component
@@ -250,7 +254,8 @@ export default [
     options: {
       validate: {
         params: pageByIdSchema,
-        payload: componentSchema
+        payload: componentSchema,
+        query: prependQuerySchema
       }
     }
   },

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -1,4 +1,5 @@
 import {
+  componentSchema,
   formMetadataInputKeys,
   formMetadataInputSchema,
   pageSchema,
@@ -6,6 +7,7 @@ import {
 } from '@defra/forms-model'
 
 import {
+  createComponentOnDraftDefinition,
   createDraftFromLive,
   createForm,
   createLiveFromDraft,
@@ -23,6 +25,7 @@ import {
   createFormSchema,
   formByIdSchema,
   formBySlugSchema,
+  pageByIdSchema,
   updateFormDefinitionSchema
 } from '~/src/models/forms.js'
 
@@ -226,6 +229,32 @@ export default [
     }
   },
   {
+    method: 'POST',
+    path: '/forms/{id}/definition/draft/pages/{pageId}/components',
+    /**
+     * @param {RequestComponent} request
+     */
+    async handler(request) {
+      const { auth, params, payload } = request
+      const { id, pageId } = params
+      const author = getAuthor(auth.credentials.user)
+      const [component] = await createComponentOnDraftDefinition(
+        id,
+        pageId,
+        [payload],
+        author
+      )
+
+      return component
+    },
+    options: {
+      validate: {
+        params: pageByIdSchema,
+        payload: componentSchema
+      }
+    }
+  },
+  {
     method: 'GET',
     path: '/forms/{id}/definition',
     /**
@@ -300,6 +329,6 @@ export default [
  * @import { FormMetadataAuthor, FormMetadata } from '@defra/forms-model'
  * @import { ServerRoute, UserCredentials } from '@hapi/hapi'
  * @import { OidcStandardClaims } from 'oidc-client-ts'
- * @import { RequestFormById, RequestFormBySlug, RequestFormDefinition, RequestFormMetadataCreate, RequestFormMetadataUpdateById, RequestListForms, RequestPage } from '~/src/api/types.js'
+ * @import { RequestFormById, RequestFormBySlug, RequestFormDefinition, RequestFormMetadataCreate, RequestFormMetadataUpdateById, RequestListForms, RequestPage, RequestComponent } from '~/src/api/types.js'
  * @import { ExtendedResponseToolkit } from '~/src/plugins/query-handler/types.js'
  */

--- a/src/routes/forms.test.js
+++ b/src/routes/forms.test.js
@@ -590,13 +590,37 @@ describe('Forms route', () => {
       expect(response.statusCode).toEqual(okStatusCode)
       expect(response.headers['content-type']).toContain(jsonContentType)
       expect(response.result).toEqual(expectedComponent)
-      const [calledFormId, calledPageId, components] =
+      const [calledFormId, calledPageId, components, , prepend] =
         createComponentOnDraftDefinitionMock.mock.calls[0]
-      expect([calledFormId, calledPageId, components]).toEqual([
+      expect([calledFormId, calledPageId, components, prepend]).toEqual([
         id,
         pageId,
-        [stubTextFieldComponent]
+        [stubTextFieldComponent],
+        false
       ])
+    })
+
+    test('Testing POST /forms/{id}/definition/draft/pages/{pageId}/components?prepend=true adds a new component to the start of a page', async () => {
+      const expectedComponent = buildTextFieldComponent({
+        ...stubTextFieldComponent,
+        id: '3813a55d-0958-47f9-8522-94b3fc3818d7'
+      })
+      const createComponentOnDraftDefinitionMock = jest
+        .mocked(createComponentOnDraftDefinition)
+        .mockResolvedValue([expectedComponent])
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/forms/${id}/definition/draft/pages/${pageId}/components?prepend=true`,
+        payload: stubTextFieldComponent,
+        auth
+      })
+
+      expect(response.statusCode).toEqual(okStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      const [, , , , prepend] =
+        createComponentOnDraftDefinitionMock.mock.calls[0]
+      expect(prepend).toBe(true)
     })
   })
 

--- a/src/routes/forms.test.js
+++ b/src/routes/forms.test.js
@@ -1,9 +1,13 @@
 import { organisations } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
-import { buildQuestionPage } from '~/src/api/forms/__stubs__/definition.js'
+import {
+  buildQuestionPage,
+  buildTextFieldComponent
+} from '~/src/api/forms/__stubs__/definition.js'
 import { FormAlreadyExistsError } from '~/src/api/forms/errors.js'
 import {
+  createComponentOnDraftDefinition,
   createDraftFromLive,
   createForm,
   createLiveFromDraft,
@@ -40,12 +44,10 @@ describe('Forms route', () => {
   const internalErrorStatusCode = 500
   const jsonContentType = 'application/json'
   const id = '661e4ca5039739ef2902b214'
+  const pageId = 'c7b9f0fa-3223-46b8-b7d3-b2bf00f37155'
   const now = new Date()
   const authorId = 'f50ceeed-b7a4-47cf-a498-094efc99f8bc'
   const authorDisplayName = 'Enrique Chase'
-  const components = {
-    TextField: 'TextField'
-  }
 
   /**
    * @satisfies {FormMetadataAuthor}
@@ -62,13 +64,10 @@ describe('Forms route', () => {
     teamEmail: 'defraforms@defra.gov.uk'
   }
 
-  const stubTextFieldComponent = /** @type {TextFieldComponent} */ {
+  const stubTextFieldComponent = buildTextFieldComponent({
     title: 'What is your name?',
-    type: components.TextField,
-    name: 'Ghcbmw',
-    options: undefined,
-    schema: {}
-  }
+    name: 'Ghcbmw'
+  })
 
   const stubPageObject = /** @type {PageStart} */ {
     title: 'What is your name?',
@@ -571,6 +570,34 @@ describe('Forms route', () => {
       expect(response.headers['content-type']).toContain(jsonContentType)
       expect(response.result).toEqual(expectedPage)
     })
+
+    test('Testing POST /forms/{id}/definition/draft/pages/{pageId}/components adds a new component to a page', async () => {
+      const expectedComponent = buildTextFieldComponent({
+        ...stubTextFieldComponent,
+        id: '3813a55d-0958-47f9-8522-94b3fc3818d7'
+      })
+      const createComponentOnDraftDefinitionMock = jest
+        .mocked(createComponentOnDraftDefinition)
+        .mockResolvedValue([expectedComponent])
+
+      const response = await server.inject({
+        method: 'POST',
+        url: `/forms/${id}/definition/draft/pages/${pageId}/components`,
+        payload: stubTextFieldComponent,
+        auth
+      })
+
+      expect(response.statusCode).toEqual(okStatusCode)
+      expect(response.headers['content-type']).toContain(jsonContentType)
+      expect(response.result).toEqual(expectedComponent)
+      const [calledFormId, calledPageId, components] =
+        createComponentOnDraftDefinitionMock.mock.calls[0]
+      expect([calledFormId, calledPageId, components]).toEqual([
+        id,
+        pageId,
+        [stubTextFieldComponent]
+      ])
+    })
   })
 
   describe('Error responses', () => {
@@ -865,6 +892,52 @@ describe('Forms route', () => {
         }
       })
     })
+
+    const invalidComponent = buildTextFieldComponent({
+      id: 'not-a-valid-id'
+    })
+
+    test.each([
+      {
+        url: `/forms/${id}/definition/draft/pages/not-a-valid-guid/components`,
+        errors: {
+          message: '"pageId" must be a valid GUID',
+          validation: {
+            keys: ['pageId'],
+            source: 'params'
+          }
+        }
+      },
+      {
+        url: `/forms/${id}/definition/draft/pages/${pageId}/components`,
+        errors: {
+          message: '"id" must be a valid GUID',
+          validation: {
+            keys: ['id'],
+            source: 'payload'
+          }
+        }
+      }
+    ])(
+      'Testing POST /forms/{id}/definition/draft/pages/{pageId}/components with invalid payload returns validation errors',
+      async ({ url, errors }) => {
+        const response = await server.inject({
+          method: 'POST',
+          url,
+          payload: invalidComponent,
+          auth
+        })
+
+        expect(response.statusCode).toEqual(badRequestStatusCode)
+        expect(response.headers['content-type']).toContain(jsonContentType)
+        expect(response.result).toMatchObject({
+          error: 'Bad Request',
+          message: errors.message,
+          statusCode: 400,
+          validation: errors.validation
+        })
+      }
+    )
 
     test.each([
       {


### PR DESCRIPTION
New endpoint to add a new component - POST /forms/:formId/definition/draft/pages/:pageId/components

Also refactors works from previous PR - the service method now handles business logic and repos purely deal with DB logic