### PR TITLE
Fixed component handling on Summary Page

### DIFF
--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -1,4 +1,8 @@
-import { ControllerType, hasComponents } from '@defra/forms-model'
+import {
+  ControllerType,
+  hasComponents,
+  hasComponentsEvenIfNoNext
+} from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 import { v4 as uuidV4 } from 'uuid'
@@ -68,7 +72,7 @@ export function findComponent(definition, pageId, componentId) {
     findPage(definition, pageId)
   )
 
-  if (!hasComponents(page)) {
+  if (!hasComponentsEvenIfNoNext(page)) {
     return undefined
   }
 


### PR DESCRIPTION
Fixed component handling on Summary Page - due to hasComponents() not handling a page if it doesn't have a 'next' attribute