### PR TITLE
Feat/468297  reorder pages

### DIFF
--- a/src/api/forms/service/definition.test.js
+++ b/src/api/forms/service/definition.test.js
@@ -1039,6 +1039,18 @@ describe('Forms service', () => {
       expect(formDefinition.upsert).not.toHaveBeenCalled()
       expect(formMetadata.update).not.toHaveBeenCalled()
     })
+
+    it('should surface errors', async () => {
+      const boomInternal = Boom.internal('Something went wrong')
+      jest.mocked(formDefinition.upsert).mockRejectedValueOnce(boomInternal)
+      await expect(
+        reorderDraftFormDefinitionPages(
+          id,
+          ['5a1c2ef7-ed4e-4ec7-9119-226fc3063bda'],
+          author
+        )
+      ).rejects.toThrow(boomInternal)
+    })
   })
 })
 

--- a/src/api/forms/service/helpers/definition.js
+++ b/src/api/forms/service/helpers/definition.js
@@ -1,0 +1,56 @@
+/**
+ * @typedef {{
+ *     [k: string]: number
+ * }} PageOrderHelper
+ */
+
+/**
+ * Creates an object of keys and their desired position based on the pageOrder
+ * @param {string[]} pageOrder
+ * @returns {PageOrderHelper}
+ */
+export function createOrder(pageOrder) {
+  return pageOrder
+    .slice()
+    .reverse()
+    .reduce((pageOrderChart, id, idx) => {
+      return {
+        ...pageOrderChart,
+        [id]: -idx
+      }
+    }, {})
+}
+
+/**
+ * Re-orders the pages in the definition
+ * @param {FormDefinition} formDefinition
+ * @param {string[]} pageOrder
+ */
+export function reorderPages(formDefinition, pageOrder) {
+  const order = createOrder(pageOrder)
+
+  return {
+    ...formDefinition,
+    pages: formDefinition.pages.toSorted((pageA, pageB) => {
+      const aId = pageA.id
+      const bId = pageB.id
+
+      const aPosition = aId !== undefined && aId in order ? order[aId] : 0
+      const bPosition = bId !== undefined && bId in order ? order[bId] : 0
+
+      if (aPosition < bPosition) {
+        return -1
+      }
+
+      if (aPosition > bPosition) {
+        return 1
+      }
+
+      return 0
+    })
+  }
+}
+
+/**
+ * @import { FormDefinition, Page } from '@defra/forms-model'
+ */

--- a/src/api/forms/service/helpers/definition.js
+++ b/src/api/forms/service/helpers/definition.js
@@ -5,7 +5,8 @@
  */
 
 /**
- * Creates an object of keys and their desired position based on the pageOrder
+ * Creates an object of keys and their desired position based on the pageOrder (pure function)
+ * For ['a','b''c'] will return { a: -2, b: -1, c: -0 }
  * @param {string[]} pageOrder
  * @returns {PageOrderHelper}
  */

--- a/src/api/forms/service/helpers/definition.test.js
+++ b/src/api/forms/service/helpers/definition.test.js
@@ -1,0 +1,90 @@
+import {
+  buildDefinition,
+  buildQuestionPage,
+  buildSummaryPage
+} from '~/src/api/forms/__stubs__/definition.js'
+import {
+  createOrder,
+  reorderPages
+} from '~/src/api/forms/service/helpers/definition.js'
+
+describe('page helpers', () => {
+  const pageOneId = '181c5e0a-9c68-44f9-a731-9699d915e5a3'
+  const pageTwoId = '37734ec9-508d-416a-9fc5-0fbb5fdd6abc'
+  const pageThreeId = '082ad4bb-fd75-457d-bf6a-c721cd7f26cc'
+  const summaryPageId = 'c5118caa-b133-4672-a616-c385a05426e8'
+
+  describe('createOrder', () => {
+    it('should create an object with orders', () => {
+      const orderDictionary = {
+        '181c5e0a-9c68-44f9-a731-9699d915e5a3': -2,
+        '37734ec9-508d-416a-9fc5-0fbb5fdd6abc': -1,
+        '082ad4bb-fd75-457d-bf6a-c721cd7f26cc': -0
+      }
+
+      expect(
+        createOrder([
+          '181c5e0a-9c68-44f9-a731-9699d915e5a3',
+          '37734ec9-508d-416a-9fc5-0fbb5fdd6abc',
+          '082ad4bb-fd75-457d-bf6a-c721cd7f26cc'
+        ])
+      ).toEqual(orderDictionary)
+    })
+  })
+
+  describe('reorderPages', () => {
+    const pageOne = buildQuestionPage({
+      title: 'Page One',
+      id: pageOneId
+    })
+    const pageTwo = buildQuestionPage({
+      title: 'Page Two',
+      id: pageTwoId
+    })
+    const pageThree = buildQuestionPage({
+      title: 'Page Three',
+      id: pageThreeId
+    })
+    const summaryPage = buildSummaryPage({
+      title: 'Summary Page',
+      id: summaryPageId
+    })
+
+    it('should reorder pages', () => {
+      const definition = buildDefinition({
+        pages: [pageTwo, pageThree, pageOne, summaryPage]
+      })
+      const expectedDefinition = buildDefinition({
+        ...definition,
+        pages: [pageOne, pageTwo, pageThree, summaryPage]
+      })
+      const pageOrder = [pageOneId, pageTwoId, pageThreeId]
+
+      expect(reorderPages(definition, pageOrder)).toEqual(expectedDefinition)
+    })
+
+    it('should do nothing if there are no pages', () => {
+      const definition = buildDefinition({
+        pages: []
+      })
+      expect(reorderPages(definition, [])).toEqual(definition)
+    })
+
+    it('should handle undefined and summary pages', () => {
+      const summaryWithoutId = buildSummaryPage({
+        ...summaryPage,
+        id: undefined
+      })
+      const pageWithoutId = buildQuestionPage({
+        id: undefined
+      })
+      const page2WithoutId = buildQuestionPage({
+        id: undefined
+      })
+      const definition = buildDefinition({
+        pages: [pageWithoutId, page2WithoutId, summaryWithoutId]
+      })
+      expect(reorderPages(definition, [])).toEqual(definition)
+    })
+  })
+})

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -11,6 +11,7 @@
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: Partial<FormMetadataInput> }>} RequestFormMetadataUpdateById
  * @typedef {Request<{ Server: { db: Db }, Query: QueryOptions }>} RequestListForms
  * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput & {version: 'v1'|'v2'}, }>} MigrateDraftFormRequest
+ * @typedef {Request<{ Server: { db: Db }, Params: FormByIdInput, Payload: string[] }>} SortDraftFormPagesRequest
  */
 
 /**

--- a/src/models/forms.js
+++ b/src/models/forms.js
@@ -69,3 +69,8 @@ export const migrateDefinitionParamSchema = Joi.object()
     version: Joi.string().allow('v1', 'v2').required()
   })
   .required()
+
+export const sortIdsSchema = Joi.array()
+  .items(Joi.string().uuid().required())
+  .min(1)
+  .required()

--- a/src/models/forms.test.js
+++ b/src/models/forms.test.js
@@ -1,0 +1,36 @@
+import { ValidationError } from 'joi'
+
+import { sortIdsSchema } from '~/src/models/forms.js'
+
+describe('forms model', () => {
+  describe('sortIdsSchema', () => {
+    it('should accept a list of uuids', () => {
+      const payload = [
+        '49e31f0d-63e4-4da4-9525-1494a7d7edc5',
+        '90c9d202-5594-4953-b77f-3a65022186c6',
+        '0cc7b818-a64f-4159-ba86-ef01f9e46e32'
+      ]
+
+      const { value, error } = sortIdsSchema.validate(payload)
+      expect(error).toBeUndefined()
+      expect(value).toEqual(payload)
+    })
+
+    it('should not accept an invalid list', () => {
+      expect(sortIdsSchema.validate([]).error).toEqual(
+        new ValidationError(
+          '"value" does not contain 1 required value(s)',
+          [],
+          []
+        )
+      )
+      expect(sortIdsSchema.validate(['not-a-valid-uuid']).error).toEqual(
+        new ValidationError(
+          '"[0]" must be a valid GUID',
+          [],
+          ['not-a-valid-uuid']
+        )
+      )
+    })
+  })
+})

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -16,6 +16,7 @@ import {
   createLiveFromDraft,
   getFormDefinition,
   listForms,
+  reorderDraftFormDefinitionPages,
   updateDraftFormDefinition
 } from '~/src/api/forms/service/definition.js'
 import {
@@ -41,6 +42,7 @@ import {
   pageByIdSchema,
   patchPageSchema,
   prependQuerySchema,
+  sortIdsSchema,
   updateFormDefinitionSchema
 } from '~/src/models/forms.js'
 
@@ -262,6 +264,24 @@ export default [
     }
   },
   {
+    method: 'POST',
+    path: '/forms/{id}/definition/draft/pages/order',
+    /**
+     * @param {SortDraftFormPagesRequest} request
+     */
+    handler(request) {
+      const { auth, params, payload } = request
+      const author = getAuthor(auth.credentials.user)
+      return reorderDraftFormDefinitionPages(params.id, payload, author)
+    },
+    options: {
+      validate: {
+        params: formByIdSchema,
+        payload: sortIdsSchema
+      }
+    }
+  },
+  {
     method: 'PATCH',
     path: '/forms/{id}/definition/draft/pages/{pageId}',
     /**
@@ -438,6 +458,6 @@ export default [
 /**
  * @import { FormMetadata } from '@defra/forms-model'
  * @import { ServerRoute } from '@hapi/hapi'
- * @import { RequestFormById, RequestFormBySlug, RequestFormDefinition, RequestFormMetadataCreate, RequestFormMetadataUpdateById, RequestListForms, RequestPage, RequestComponent, PatchPageRequest, RequestUpdateComponent, MigrateDraftFormRequest } from '~/src/api/types.js'
+ * @import { RequestFormById, RequestFormBySlug, RequestFormDefinition, RequestFormMetadataCreate, RequestFormMetadataUpdateById, RequestListForms, RequestPage, RequestComponent, PatchPageRequest, RequestUpdateComponent, MigrateDraftFormRequest, SortDraftFormPagesRequest } from '~/src/api/types.js'
  * @import { ExtendedResponseToolkit } from '~/src/plugins/query-handler/types.js'
  */


### PR DESCRIPTION
## Re-order pages endpoint

API for https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/468297

Endpoint for updating the ordering of pages in a draft definition:

POST /forms/:id/definition/draft/pages/order

[
  "7ec759c3-1bcf-4f82-aa98-8a1682250e00",
  "27dfab66-0ebc-4b83-bddc-b5fe56b12682",
  "31cc5395-80f0-43ec-b02c-345c11aecaed"
]

Ids not included in the list (namely Summary page) are ignored and given a sort order of 0.  

Updates a whole form definition in one go as an interim solution.  If we have conflicts we can look into this again.