### PR TITLE
Feat/516117  migration step 2

### DIFF
--- a/src/api/forms/service/migration-helpers.js
+++ b/src/api/forms/service/migration-helpers.js
@@ -93,6 +93,20 @@ export function populateComponentIds(pageWithoutComponentIds) {
   }
 }
 
+const migrationSteps = [repositionSummary]
+
+/**
+ * Apply transformations to FormDefinition
+ * @param {FormDefinition} definition
+ * @returns {FormDefinition} definition
+ */
+function applyMigrationSteps(definition) {
+  return migrationSteps.reduce(
+    (acc, transformation) => transformation(acc),
+    definition
+  )
+}
+
 /**
  * Migrates a v1 definition to v2
  * @param {FormDefinition} definition
@@ -108,9 +122,11 @@ export function migrateToV2(definition) {
     throw error
   }
 
-  value.engine = Engine.V2
+  const migratedDefinition = applyMigrationSteps(value)
 
-  return repositionSummary(value)
+  migratedDefinition.engine = Engine.V2
+
+  return migratedDefinition
 }
 
 /**

--- a/src/api/forms/service/migration-helpers.js
+++ b/src/api/forms/service/migration-helpers.js
@@ -142,19 +142,22 @@ export function convertDeclaration(originalDefinition) {
   const summaryPage = definition.pages.find(
     (p) => p.controller === ControllerType.Summary
   )
-  if (!summaryPage) {
-    throw new Error('Cannot migrate as unable to find Summary Page')
+
+  if (!summaryPage && definition.declaration) {
+    throw new Error('Cannot migrate declaration as unable to find Summary Page')
   }
 
-  summaryPage.components = summaryPage.components ?? []
+  if (summaryPage) {
+    summaryPage.components = summaryPage.components ?? []
 
-  if (definition.declaration) {
-    const declaration = /** @type {MarkdownComponent} */ (
-      getComponentDefaults({ type: ComponentType.Markdown })
-    )
-    declaration.content = definition.declaration
-    summaryPage.components.unshift(declaration)
-    delete definition.declaration
+    if (definition.declaration) {
+      const declaration = /** @type {MarkdownComponent} */ (
+        getComponentDefaults({ type: ComponentType.Markdown })
+      )
+      declaration.content = definition.declaration
+      summaryPage.components.unshift(declaration)
+      delete definition.declaration
+    }
   }
 
   return definition

--- a/src/api/forms/service/migration-helpers.js
+++ b/src/api/forms/service/migration-helpers.js
@@ -143,12 +143,12 @@ export function convertDeclaration(originalDefinition) {
     (p) => p.controller === ControllerType.Summary
   )
   if (!summaryPage) {
-    return definition
+    throw new Error('Cannot migrate as unable to find Summary Page')
   }
 
   summaryPage.components = summaryPage.components ?? []
 
-  if (definition.declaration !== undefined && definition.declaration !== '') {
+  if (definition.declaration) {
     const declaration = /** @type {MarkdownComponent} */ (
       getComponentDefaults({ type: ComponentType.Markdown })
     )

--- a/src/api/forms/service/migration-helpers.js
+++ b/src/api/forms/service/migration-helpers.js
@@ -81,10 +81,7 @@ export function repositionSummary(definition) {
  */
 export function applyPageTitles(definition) {
   const changedPages = definition.pages.map((page) => {
-    if (
-      page.controller !== ControllerType.Summary &&
-      (!page.title || page.title === '')
-    ) {
+    if (page.controller !== ControllerType.Summary && !page.title) {
       return {
         ...page,
         title: hasComponents(page) ? page.components[0].title : ''
@@ -143,21 +140,25 @@ export function convertDeclaration(originalDefinition) {
     (p) => p.controller === ControllerType.Summary
   )
 
+  if (summaryPage) {
+    summaryPage.components = summaryPage.components ?? []
+  }
+
   if (!summaryPage && definition.declaration) {
     throw new Error('Cannot migrate declaration as unable to find Summary Page')
   }
 
-  if (summaryPage) {
-    summaryPage.components = summaryPage.components ?? []
+  if (!summaryPage && !definition.declaration) {
+    return definition
+  }
 
-    if (definition.declaration) {
-      const declaration = /** @type {MarkdownComponent} */ (
-        getComponentDefaults({ type: ComponentType.Markdown })
-      )
-      declaration.content = definition.declaration
-      summaryPage.components.unshift(declaration)
-      delete definition.declaration
-    }
+  if (definition.declaration) {
+    const declaration = /** @type {MarkdownComponent} */ (
+      getComponentDefaults({ type: ComponentType.Markdown })
+    )
+    declaration.content = definition.declaration
+    summaryPage.components.unshift(declaration)
+    delete definition.declaration
   }
 
   return definition

--- a/src/api/forms/service/migration-helpers.js
+++ b/src/api/forms/service/migration-helpers.js
@@ -81,7 +81,10 @@ export function repositionSummary(definition) {
  */
 export function applyPageTitles(definition) {
   const changedPages = definition.pages.map((page) => {
-    if (page.controller !== ControllerType.Summary && !page.title) {
+    if (
+      page.controller !== ControllerType.Summary &&
+      (!page.title || page.title === '')
+    ) {
       return {
         ...page,
         title: hasComponents(page) ? page.components[0].title : ''
@@ -140,25 +143,21 @@ export function convertDeclaration(originalDefinition) {
     (p) => p.controller === ControllerType.Summary
   )
 
-  if (summaryPage) {
-    summaryPage.components = summaryPage.components ?? []
-  }
-
   if (!summaryPage && definition.declaration) {
     throw new Error('Cannot migrate declaration as unable to find Summary Page')
   }
 
-  if (!summaryPage && !definition.declaration) {
-    return definition
-  }
+  if (summaryPage) {
+    summaryPage.components = summaryPage.components ?? []
 
-  if (definition.declaration) {
-    const declaration = /** @type {MarkdownComponent} */ (
-      getComponentDefaults({ type: ComponentType.Markdown })
-    )
-    declaration.content = definition.declaration
-    summaryPage.components.unshift(declaration)
-    delete definition.declaration
+    if (definition.declaration) {
+      const declaration = /** @type {MarkdownComponent} */ (
+        getComponentDefaults({ type: ComponentType.Markdown })
+      )
+      declaration.content = definition.declaration
+      summaryPage.components.unshift(declaration)
+      delete definition.declaration
+    }
   }
 
   return definition
@@ -228,6 +227,6 @@ export function migrateToV2(definition) {
 }
 
 /**
- * @import { ComponentDef, FormDefinition, MarkdownComponent, Page, PageSummary } from '@defra/forms-model'
+ * @import { FormDefinition, MarkdownComponent, Page, PageSummary } from '@defra/forms-model'
  * @import { ValidationError } from 'joi'
  */

--- a/src/api/forms/service/migration-helpers.js
+++ b/src/api/forms/service/migration-helpers.js
@@ -72,6 +72,22 @@ export function repositionSummary(definition) {
 }
 
 /**
+ * Applies page titles if they are missing
+ * @param {FormDefinition} definition
+ */
+export function applyPageTitles(definition) {
+  for (const page of definition.pages.filter(
+    (p) => p.controller !== ControllerType.Summary
+  )) {
+    if (!page.title || page.title === '') {
+      page.title = hasComponents(page) ? page.components[0].title : ''
+    }
+  }
+
+  return definition
+}
+
+/**
  * @param {Page} pageWithoutComponentIds
  */
 export function populateComponentIds(pageWithoutComponentIds) {
@@ -93,7 +109,7 @@ export function populateComponentIds(pageWithoutComponentIds) {
   }
 }
 
-const migrationSteps = [repositionSummary]
+const migrationSteps = [repositionSummary, applyPageTitles]
 
 /**
  * Apply transformations to FormDefinition

--- a/src/api/forms/service/migration-helpers.js
+++ b/src/api/forms/service/migration-helpers.js
@@ -81,10 +81,7 @@ export function repositionSummary(definition) {
  */
 export function applyPageTitles(definition) {
   const changedPages = definition.pages.map((page) => {
-    if (
-      page.controller !== ControllerType.Summary &&
-      (!page.title || page.title === '')
-    ) {
+    if (page.controller !== ControllerType.Summary && !page.title) {
       return {
         ...page,
         title: hasComponents(page) ? page.components[0].title : ''

--- a/src/api/forms/service/migration-helpers.test.js
+++ b/src/api/forms/service/migration-helpers.test.js
@@ -493,17 +493,18 @@ describe('migration helpers', () => {
       expect(res.declaration).toBeUndefined()
     })
 
-    it('should throw if no summary page', () => {
+    it('should throw if no summary page but a declaration', () => {
       const testDefinition3 = buildDefinition({
         pages: [],
         sections: [
           { hideTitle: false, name: 'section', title: 'Section title' }
         ],
-        engine: Engine.V1
+        engine: Engine.V1,
+        declaration: 'Some declaration'
       })
 
       expect(() => convertDeclaration(testDefinition3)).toThrow(
-        'Cannot migrate as unable to find Summary Page'
+        'Cannot migrate declaration as unable to find Summary Page'
       )
     })
   })

--- a/src/api/forms/service/migration-helpers.test.js
+++ b/src/api/forms/service/migration-helpers.test.js
@@ -492,6 +492,20 @@ describe('migration helpers', () => {
       expect(summaryPageRes.components).toHaveLength(0)
       expect(res.declaration).toBeUndefined()
     })
+
+    it('should throw if no summary page', () => {
+      const testDefinition3 = buildDefinition({
+        pages: [],
+        sections: [
+          { hideTitle: false, name: 'section', title: 'Section title' }
+        ],
+        engine: Engine.V1
+      })
+
+      expect(() => convertDeclaration(testDefinition3)).toThrow(
+        'Cannot migrate as unable to find Summary Page'
+      )
+    })
   })
 })
 


### PR DESCRIPTION
Added migration steps:
- migrateComponentFields - populate shortDescription from title
- convertDeclaration - add declaration text as guidance component in Summary page, and remove root-level declaration property