### PR TITLE
feat: 512490 - Use FormStatus enum rather than FormStatus and State t…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/forms-model": "^3.0.412",
+        "@defra/forms-model": "^3.0.416",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.3.12",
@@ -1729,9 +1729,9 @@
       "dev": true
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.412",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.412.tgz",
-      "integrity": "sha512-TzTXI2rHCSJZ3PerA8RNbmxx/UPPpSXcNciCJDE8HyvWHCfM+hLye7+zyeBpWDSCl5R3J43pizVAN7mbJDWWQA==",
+      "version": "3.0.416",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.416.tgz",
+      "integrity": "sha512-s2cunrCAgvNGYXOklI1sOfF9KU4iRk1O/qP6oYZUu2lkQu32vxlPxKSmaJYy1ti/dPRPdA93nHEs0tH5AxHXGg==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "marked": "^15.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "dependencies": {
-    "@defra/forms-model": "^3.0.412",
+    "@defra/forms-model": "^3.0.416",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.3.12",

--- a/src/api/forms/repositories/aggregation/form-metadata-aggregation.js
+++ b/src/api/forms/repositories/aggregation/form-metadata-aggregation.js
@@ -1,3 +1,5 @@
+import { FormStatus } from '@defra/forms-model'
+
 import { escapeRegExp } from '~/src/helpers/string-utils.js'
 
 /**
@@ -25,7 +27,9 @@ export function buildFilterConditions(options) {
 
   if (status && status.length > 0) {
     conditions.$or = status.map((s) =>
-      s === 'live' ? { live: { $exists: true } } : { live: { $exists: false } }
+      s === FormStatus.Live
+        ? { live: { $exists: true } }
+        : { live: { $exists: false } }
     )
   }
 
@@ -278,7 +282,7 @@ export function processFilterResults(filterResults) {
  */
 
 /**
- * @import { FormStatus, FilterOptions } from '@defra/forms-model'
+ * @import { FilterOptions } from '@defra/forms-model'
  */
 
 /**

--- a/src/api/forms/repositories/aggregation/form-metadata-aggregation.test.js
+++ b/src/api/forms/repositories/aggregation/form-metadata-aggregation.test.js
@@ -1,3 +1,5 @@
+import { FormStatus } from '@defra/forms-model'
+
 import {
   addDateFieldStage,
   addRankingStage,
@@ -56,14 +58,14 @@ describe('Form metadata aggregation', () => {
 
     describe('with status filter', () => {
       it('should create status filter for live forms', () => {
-        const result = buildFilterConditions({ status: ['live'] })
+        const result = buildFilterConditions({ status: [FormStatus.Live] })
         expect(result).toEqual({
           $or: [{ live: { $exists: true } }]
         })
       })
 
       it('should create status filter for draft forms', () => {
-        const result = buildFilterConditions({ status: ['draft'] })
+        const result = buildFilterConditions({ status: [FormStatus.Draft] })
         expect(result).toEqual({
           $or: [{ live: { $exists: false } }]
         })
@@ -72,7 +74,9 @@ describe('Form metadata aggregation', () => {
 
     describe('with multiple status values', () => {
       it('should create combined status filter', () => {
-        const result = buildFilterConditions({ status: ['live', 'draft'] })
+        const result = buildFilterConditions({
+          status: [FormStatus.Live, FormStatus.Draft]
+        })
         expect(result).toEqual({
           $or: [{ live: { $exists: true } }, { live: { $exists: false } }]
         })
@@ -85,7 +89,7 @@ describe('Form metadata aggregation', () => {
           title: 'Wildlife Permit Application',
           author: 'Henrique Silva',
           organisations: ['Natural England', 'Defra'],
-          status: ['live']
+          status: [FormStatus.Live]
         })
 
         expect(result).toEqual({
@@ -125,7 +129,7 @@ describe('Form metadata aggregation', () => {
           'Wildlife Permit Application',
           'Henrique',
           ['Defra'],
-          ['live']
+          [FormStatus.Live]
         )
 
         expect(pipeline[0]).toHaveProperty('$match')
@@ -305,7 +309,7 @@ describe('Form metadata aggregation', () => {
           { name: 'Sarah Wilson (Natural England)' }
         ],
         organisations: [{ name: 'Defra' }, { name: 'Natural England' }],
-        status: [{ statuses: ['live', 'draft'] }]
+        status: [{ statuses: [FormStatus.Live, FormStatus.Draft] }]
       }
 
       const result = processFilterResults(filterResults)

--- a/src/api/forms/repositories/form-definition-repository.test.js
+++ b/src/api/forms/repositories/form-definition-repository.test.js
@@ -1,4 +1,4 @@
-import { ControllerType, Engine } from '@defra/forms-model'
+import { ControllerType, Engine, FormStatus } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 
@@ -35,11 +35,6 @@ const mockSession = author
 const formId = '1eabd1437567fe1b26708bbb'
 const pageId = '87ffdbd3-9e43-41e2-8db3-98ade26ca0b7'
 const componentId = 'e296d931-2364-4b17-9049-1aa1afea29d3'
-
-/**
- * @typedef {'draft' | 'live'} State
- */
-const DRAFT = /** @type {State} */ ('draft')
 
 jest.mock('~/src/mongo.js', () => {
   let isPrepared = false
@@ -101,7 +96,7 @@ describe('form-definition-repository', () => {
     })
 
     it('should handle a call inside a session', async () => {
-      await get(formId, DRAFT, mockSession)
+      await get(formId, FormStatus.Draft, mockSession)
       const [, options] = mockCollection.findOne.mock.calls[0]
 
       expect(options).toEqual({
@@ -118,7 +113,7 @@ describe('form-definition-repository', () => {
           formId,
           { controller: ControllerType.Summary },
           mockSession,
-          'live'
+          FormStatus.Live
         )
       ).rejects.toThrow(
         Boom.badRequest(
@@ -148,7 +143,9 @@ describe('form-definition-repository', () => {
 
     it('should not edit a live summary', async () => {
       await expect(
-        addPageAtPosition('1234', page, mockSession, { state: 'live' })
+        addPageAtPosition('1234', page, mockSession, {
+          state: FormStatus.Live
+        })
       ).rejects.toThrow(
         Boom.badRequest('Cannot remove add on live form ID 1234')
       )
@@ -191,7 +188,7 @@ describe('form-definition-repository', () => {
 
     it('should fail if form is live', async () => {
       await expect(
-        updatePage(formId, pageId, page, mockSession, 'live')
+        updatePage(formId, pageId, page, mockSession, FormStatus.Live)
       ).rejects.toThrow(
         Boom.badRequest(
           'Cannot update page on a live form - 1eabd1437567fe1b26708bbb'
@@ -220,7 +217,7 @@ describe('form-definition-repository', () => {
     it('should fail if form is live', async () => {
       await expect(
         addComponents(formId, pageId, [component], mockSession, {
-          state: 'live'
+          state: FormStatus.Live
         })
       ).rejects.toThrow(
         Boom.badRequest(
@@ -336,7 +333,7 @@ describe('form-definition-repository', () => {
           componentId,
           component,
           mockSession,
-          'live'
+          FormStatus.Live
         )
       ).rejects.toThrow(
         Boom.badRequest(
@@ -413,7 +410,13 @@ describe('form-definition-repository', () => {
 
     it('should fail if form is live', async () => {
       await expect(
-        updatePageFields(formId, pageId, pageFields, mockSession, 'live')
+        updatePageFields(
+          formId,
+          pageId,
+          pageFields,
+          mockSession,
+          FormStatus.Live
+        )
       ).rejects.toThrow(
         Boom.badRequest(
           'Cannot update pageFields on a live form - 1eabd1437567fe1b26708bbb'
@@ -425,7 +428,13 @@ describe('form-definition-repository', () => {
   describe('deleteComponent', () => {
     it('should fail if form is live', async () => {
       await expect(
-        deleteComponent(formId, pageId, componentId, mockSession, 'live')
+        deleteComponent(
+          formId,
+          pageId,
+          componentId,
+          mockSession,
+          FormStatus.Live
+        )
       ).rejects.toThrow(
         Boom.badRequest(
           'Cannot delete component on a live form - 1eabd1437567fe1b26708bbb'
@@ -452,7 +461,13 @@ describe('form-definition-repository', () => {
     it('should fail if form is live', async () => {
       const mockDefinition = buildDefinition({})
       await expect(
-        setEngineVersion(formId, Engine.V2, mockDefinition, mockSession, 'live')
+        setEngineVersion(
+          formId,
+          Engine.V2,
+          mockDefinition,
+          mockSession,
+          FormStatus.Live
+        )
       ).rejects.toThrow(
         Boom.badRequest('Cannot update the engine version of a live form')
       )

--- a/src/api/forms/repositories/helpers.test.js
+++ b/src/api/forms/repositories/helpers.test.js
@@ -34,7 +34,7 @@ describe('repository helpers', () => {
   const statusPage = buildStatusPage({})
 
   const componentWithoutAnId = buildTextFieldComponent({
-    name: 'CwAid'
+    name: 'Ghcbmw'
   })
   delete componentWithoutAnId.id
 

--- a/src/api/forms/service/__stubs__/service.js
+++ b/src/api/forms/service/__stubs__/service.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import { FormStatus } from '@defra/forms-model'
 import { ObjectId } from 'mongodb'
 
 import { getAuthor } from '~/src/helpers/get-author.js'
@@ -102,7 +103,7 @@ export const formMetadataWithLiveDocument = {
 export const mockFilters = {
   authors: ['Joe Bloggs', 'Jane Doe', 'Enrique Chase'],
   organisations: ['Defra', 'Natural England'],
-  status: ['live', DRAFT]
+  status: [FormStatus.Live, FormStatus.Draft]
 }
 
 /**

--- a/src/api/forms/service/component.js
+++ b/src/api/forms/service/component.js
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 
+import { FormStatus } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
@@ -7,11 +8,7 @@ import * as formMetadata from '~/src/api/forms/repositories/form-metadata-reposi
 import { findComponent } from '~/src/api/forms/repositories/helpers.js'
 import { getFormDefinition } from '~/src/api/forms/service/definition.js'
 import { getFormDefinitionPage } from '~/src/api/forms/service/page.js'
-import {
-  DRAFT,
-  logger,
-  partialAuditFields
-} from '~/src/api/forms/service/shared.js'
+import { logger, partialAuditFields } from '~/src/api/forms/service/shared.js'
 import { client } from '~/src/mongo.js'
 
 /**
@@ -44,7 +41,7 @@ export async function getFormDefinitionPageComponent(
 
   const definition = /** @type {FormDefinition} */ await getFormDefinition(
     formId,
-    DRAFT,
+    FormStatus.Draft,
     session
   )
   const component = findComponent(definition, pageId, componentId)
@@ -98,7 +95,7 @@ export async function createComponentOnDraftDefinition(
         pageId,
         createdComponents,
         session,
-        { state: DRAFT, ...positionOptions }
+        { state: FormStatus.Draft, ...positionOptions }
       )
 
       // Update the form with the new draft state
@@ -154,7 +151,7 @@ export async function updateComponentOnDraftDefinition(
             componentId,
             componentPayload,
             session,
-            DRAFT
+            FormStatus.Draft
           )
 
         // Update the form with the new draft state
@@ -210,7 +207,7 @@ export async function deleteComponentOnDraftDefinition(
           pageId,
           componentId,
           session,
-          DRAFT
+          FormStatus.Draft
         )
 
         // Update the form with the new draft state

--- a/src/api/forms/service/component.test.js
+++ b/src/api/forms/service/component.test.js
@@ -1,3 +1,4 @@
+import { FormStatus } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { pino } from 'pino'
 
@@ -162,7 +163,7 @@ describe('Forms service', () => {
       expect(components).toEqual([
         { ...textFieldComponent, id: expect.any(String) }
       ])
-      expect(state).toEqual({ state: DRAFT })
+      expect(state).toEqual({ state: FormStatus.Draft })
 
       expect(metaFormId).toBe('123')
 
@@ -191,7 +192,7 @@ describe('Forms service', () => {
 
       const [, , , , options] = dbDefinitionSpy.mock.calls[0]
 
-      expect(options).toEqual({ state: DRAFT, position: 0 })
+      expect(options).toEqual({ state: FormStatus.Draft, position: 0 })
     })
 
     it('should fail if page does not exist', async () => {

--- a/src/api/forms/service/definition.js
+++ b/src/api/forms/service/definition.js
@@ -1,3 +1,4 @@
+import { FormStatus } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
 import { makeFormLiveErrorMessages } from '~/src/api/forms/constants.js'
@@ -6,7 +7,6 @@ import * as formMetadata from '~/src/api/forms/repositories/form-metadata-reposi
 import { reorderPages } from '~/src/api/forms/service/helpers/definition.js'
 import { getForm } from '~/src/api/forms/service/index.js'
 import {
-  DRAFT,
   logger,
   mapForm,
   partialAuditFields
@@ -28,10 +28,14 @@ export async function listForms(options) {
 /**
  * Retrieves the form definition content for a given form ID
  * @param {string} formId - the ID of the form
- * @param {State} state - the form state
+ * @param {FormStatus} state - the form state
  * @param {ClientSession | undefined} [session]
  */
-export function getFormDefinition(formId, state = DRAFT, session = undefined) {
+export function getFormDefinition(
+  formId,
+  state = FormStatus.Draft,
+  session = undefined
+) {
   // TODO: if form def is v1 and target v2 - use decorator
   return formDefinition.get(formId, state, session)
 }
@@ -122,7 +126,10 @@ export async function createLiveFromDraft(formId, author) {
       throw Boom.badRequest(makeFormLiveErrorMessages.missingPrivacyNotice)
     }
 
-    const draftFormDefinition = await formDefinition.get(formId, DRAFT)
+    const draftFormDefinition = await formDefinition.get(
+      formId,
+      FormStatus.Draft
+    )
 
     if (!draftFormDefinition.startPage) {
       throw Boom.badRequest(makeFormLiveErrorMessages.missingStartPage)
@@ -147,7 +154,7 @@ export async function createLiveFromDraft(formId, author) {
           updatedAt: now,
           updatedBy: author
         }
-      : partialAuditFields(now, author, 'live') // Partially update the live state fields
+      : partialAuditFields(now, author, FormStatus.Live) // Partially update the live state fields
 
     const session = client.startSession()
 

--- a/src/api/forms/service/definition.test.js
+++ b/src/api/forms/service/definition.test.js
@@ -1,3 +1,4 @@
+import { FormStatus } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 import { pino } from 'pino'
@@ -48,7 +49,6 @@ const { empty: emptyFormWithSummary } = /** @type {typeof formTemplates} */ (
   jest.requireActual('~/src/api/forms/templates.js')
 )
 const author = getAuthor()
-const DRAFT = 'draft'
 
 describe('Forms service', () => {
   const id = '661e4ca5039739ef2902b214'
@@ -851,7 +851,7 @@ describe('Forms service', () => {
           perPage: 10,
           author: 'Henrique Chase',
           organisations: ['Defra'],
-          status: ['live']
+          status: [FormStatus.Live]
         }
 
         jest.mocked(formMetadata.list).mockResolvedValue({
@@ -877,7 +877,7 @@ describe('Forms service', () => {
           perPage: 10,
           author: 'Henrique Chase',
           organisations: ['Defra', 'Natural England'],
-          status: ['live', DRAFT]
+          status: [FormStatus.Live, FormStatus.Draft]
         }
 
         jest.mocked(formMetadata.list).mockResolvedValue({

--- a/src/api/forms/service/migration-helpers.test.js
+++ b/src/api/forms/service/migration-helpers.test.js
@@ -26,17 +26,17 @@ describe('migration helpers', () => {
   })
 
   const componentWithoutAnId = buildTextFieldComponent({
-    name: 'CwAid'
+    name: 'Ghcbma'
   })
   delete componentWithoutAnId.id
 
   const componentOne = buildTextFieldComponent({
     id: '380429e0-2d2d-4fbf-90fb-34364f488af1',
-    name: 'CwAid1'
+    name: 'Ghcbmb'
   })
   const componentTwo = buildTextFieldComponent({
     id: '52e34be1-a528-4e10-a5eb-06aed317fb7f',
-    name: 'CwAid2'
+    name: 'Ghcbmw'
   })
   const componentOneNoId = buildTextFieldComponent({
     ...componentOne,

--- a/src/api/forms/service/migration.js
+++ b/src/api/forms/service/migration.js
@@ -1,4 +1,4 @@
-import { ControllerType, Engine } from '@defra/forms-model'
+import { ControllerType, Engine, FormStatus } from '@defra/forms-model'
 
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
 import * as formMetadata from '~/src/api/forms/repositories/form-metadata-repository.js'
@@ -7,11 +7,7 @@ import {
   summaryHelper
 } from '~/src/api/forms/service/migration-helpers.js'
 import { addIdToSummary } from '~/src/api/forms/service/page.js'
-import {
-  DRAFT,
-  logger,
-  partialAuditFields
-} from '~/src/api/forms/service/shared.js'
+import { logger, partialAuditFields } from '~/src/api/forms/service/shared.js'
 import { client } from '~/src/mongo.js'
 
 /**
@@ -82,7 +78,7 @@ export async function repositionSummaryPipeline(formId, definition, author) {
  * @param {FormMetadataAuthor} author
  */
 export async function migrateDefinitionToV2(formId, author) {
-  const formDraftDefinition = await formDefinition.get(formId, DRAFT)
+  const formDraftDefinition = await formDefinition.get(formId, FormStatus.Draft)
 
   if (formDraftDefinition.engine === Engine.V2) {
     return formDraftDefinition

--- a/src/api/forms/service/page.js
+++ b/src/api/forms/service/page.js
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 
-import { Engine } from '@defra/forms-model'
+import { Engine, FormStatus } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
@@ -12,7 +12,6 @@ import {
 import { getFormDefinition } from '~/src/api/forms/service/definition.js'
 import { repositionSummaryPipeline } from '~/src/api/forms/service/migration.js'
 import {
-  DRAFT,
   SUMMARY_PAGE_ID,
   logger,
   partialAuditFields
@@ -50,7 +49,7 @@ export async function createPageOnDraftDefinition(formId, newPage, author) {
   const session = client.startSession()
 
   /** @type {FormDefinition} */
-  const formDraftDefinition = await getFormDefinition(formId, DRAFT)
+  const formDraftDefinition = await getFormDefinition(formId, FormStatus.Draft)
 
   uniquePathGate(
     formDraftDefinition,
@@ -65,7 +64,7 @@ export async function createPageOnDraftDefinition(formId, newPage, author) {
   )
 
   /**
-   * @type {{ position?: number; state?: 'live' | 'draft' }}
+   * @type {{ position?: number; state?: FormStatus }}
    */
   const options = {}
 
@@ -117,7 +116,7 @@ export async function getFormDefinitionPage(formId, pageId, session) {
 
   const definition = /** @type {FormDefinition} */ await getFormDefinition(
     formId,
-    DRAFT,
+    FormStatus.Draft,
     session
   )
 
@@ -161,7 +160,7 @@ export async function patchFieldsOnDraftDefinitionPage(
           pageId,
           pageFieldsToUpdate,
           session,
-          DRAFT
+          FormStatus.Draft
         )
 
         page = await getFormDefinitionPage(formId, pageId, session)

--- a/src/api/forms/service/shared.js
+++ b/src/api/forms/service/shared.js
@@ -1,3 +1,5 @@
+import { FormStatus } from '@defra/forms-model'
+
 import { createLogger } from '~/src/helpers/logging/logger.js'
 
 export const logger = createLogger()
@@ -6,19 +8,15 @@ export const defaultAuthor = {
   id: '-1'
 }
 export const defaultDate = new Date('2024-06-25T23:00:00Z') // date we went live
-/**
- * @typedef {'draft' | 'live'} State
- */
 
-export const DRAFT = /** @type {State} */ ('draft')
 /**
  * Partially update the [state] fields
  * @param {Date} date
  * @param {FormMetadataAuthor} author
- * @param {string} state
+ * @param {FormStatus} state
  * @returns {PartialFormMetadataDocument}
  */
-export function partialAuditFields(date, author, state = DRAFT) {
+export function partialAuditFields(date, author, state = FormStatus.Draft) {
   return /** @type {PartialFormMetadataDocument} */ {
     [`${state}.updatedAt`]: date,
     [`${state}.updatedBy`]: author,

--- a/src/routes/forms.js
+++ b/src/routes/forms.js
@@ -1,4 +1,5 @@
 import {
+  FormStatus,
   componentSchema,
   formMetadataInputKeys,
   formMetadataInputSchema,
@@ -394,7 +395,7 @@ export default [
       const { params } = request
       const { id } = params
 
-      return getFormDefinition(id, 'live')
+      return getFormDefinition(id, FormStatus.Live)
     },
     options: {
       auth: false,

--- a/src/routes/forms.test.js
+++ b/src/routes/forms.test.js
@@ -1,4 +1,4 @@
-import { organisations } from '@defra/forms-model'
+import { FormStatus, organisations } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
 import {
@@ -140,7 +140,7 @@ describe('Forms route', () => {
   const mockFilters = {
     authors: ['Joe Bloggs', 'Jane Doe', 'Enrique Chase'],
     organisations: ['Defra', 'Natural England'],
-    status: ['live', 'draft']
+    status: [FormStatus.Live, FormStatus.Draft]
   }
 
   describe('Success responses', () => {


### PR DESCRIPTION
## Update to FormStatus enum on Manager

These are the manager changes to line up with the change from `FormStatus` type into an enum.  Requires the new model.