### PR TITLE
Fix/529912 duplicate page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/forms-model": "^3.0.439",
+        "@defra/forms-model": "^3.0.440",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.4.0",
@@ -1729,9 +1729,9 @@
       "dev": true
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.439",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.439.tgz",
-      "integrity": "sha512-fr4tIiJvFSXv9Tv1jidErpmg591oAhC2CWLXQliha0VGHnAutOC8flq1/mcx6uUIMPCQoa6sofJdjJGT6TlBYw==",
+      "version": "3.0.440",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.440.tgz",
+      "integrity": "sha512-VQoGrqbDAHpfMaC2LX/P8Q49xBCBEE5mmRju+P3OdTEAFSBKcIq6jLAggypWeVNzbl8irwqF2X4QBF1kpxPysA==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "marked": "^15.0.7",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module"
   },
   "dependencies": {
-    "@defra/forms-model": "^3.0.439",
+    "@defra/forms-model": "^3.0.440",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.4.0",

--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -1,7 +1,4 @@
-import {
-  ApiErrorFunctionCode,
-  hasComponentsEvenIfNoNext
-} from '@defra/forms-model'
+import { ApiErrorCode, hasComponentsEvenIfNoNext } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 
@@ -56,14 +53,14 @@ export function findComponent(definition, pageId, componentId) {
  * @param {FormDefinition} formDraftDefinition
  * @param {string} path
  * @param {string} message
- * @param {ApiErrorFunctionCode} [functionCode]
+ * @param {ApiErrorCode} [errorCode]
  * @param {string} [excludePageId]
  */
 export function uniquePathGate(
   formDraftDefinition,
   path,
   message,
-  functionCode = ApiErrorFunctionCode.General,
+  errorCode = ApiErrorCode.General,
   excludePageId = ''
 ) {
   if (
@@ -71,7 +68,7 @@ export function uniquePathGate(
       (page) => page.path === path && page.id !== excludePageId
     )
   ) {
-    throw Boom.conflict(message, { functionCode })
+    throw Boom.conflict(message, { errorCode })
   }
 }
 

--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -1,4 +1,7 @@
-import { hasComponentsEvenIfNoNext } from '@defra/forms-model'
+import {
+  ApiErrorFunctionCode,
+  hasComponentsEvenIfNoNext
+} from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 
@@ -53,10 +56,22 @@ export function findComponent(definition, pageId, componentId) {
  * @param {FormDefinition} formDraftDefinition
  * @param {string} path
  * @param {string} message
+ * @param {ApiErrorFunctionCode} [functionCode]
+ * @param {string} [excludePageId]
  */
-export const uniquePathGate = (formDraftDefinition, path, message) => {
-  if (formDraftDefinition.pages.some((page) => page.path === path)) {
-    throw Boom.conflict(message)
+export const uniquePathGate = (
+  formDraftDefinition,
+  path,
+  message,
+  functionCode = ApiErrorFunctionCode.General,
+  excludePageId = ''
+) => {
+  if (
+    formDraftDefinition.pages.some(
+      (page) => page.path === path && page.id !== excludePageId
+    )
+  ) {
+    throw Boom.conflict(message, { functionCode })
   }
 }
 

--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -59,13 +59,13 @@ export function findComponent(definition, pageId, componentId) {
  * @param {ApiErrorFunctionCode} [functionCode]
  * @param {string} [excludePageId]
  */
-export const uniquePathGate = (
+export function uniquePathGate(
   formDraftDefinition,
   path,
   message,
   functionCode = ApiErrorFunctionCode.General,
   excludePageId = ''
-) => {
+) {
   if (
     formDraftDefinition.pages.some(
       (page) => page.path === path && page.id !== excludePageId

--- a/src/api/forms/repositories/helpers.test.js
+++ b/src/api/forms/repositories/helpers.test.js
@@ -1,3 +1,5 @@
+import { ObjectId } from 'mongodb'
+
 import {
   buildDefinition,
   buildQuestionPage,
@@ -5,10 +7,61 @@ import {
   buildSummaryPage,
   buildTextFieldComponent
 } from '~/src/api/forms/__stubs__/definition.js'
+import { buildMockCollection } from '~/src/api/forms/__stubs__/mongo.js'
 import {
   findComponent,
-  findPage
+  findPage,
+  removeById
 } from '~/src/api/forms/repositories/helpers.js'
+import { getAuthor } from '~/src/helpers/get-author.js'
+import { db } from '~/src/mongo.js'
+
+jest.mock('~/src/helpers/get-author.js')
+
+const mockCollection = buildMockCollection()
+
+const author = getAuthor()
+/**
+ * @type {any}
+ */
+const mockSession = author
+const collectionId = '111bd1111222fe1b33333ccc'
+
+jest.mock('~/src/mongo.js', () => {
+  let isPrepared = false
+  const collection =
+    /** @satisfies {Collection<{draft: FormDefinition}>} */ jest
+      .fn()
+      .mockImplementation(() => mockCollection)
+  return {
+    db: {
+      collection
+    },
+    get client() {
+      if (!isPrepared) {
+        return undefined
+      }
+
+      return {
+        startSession: () => ({
+          endSession: jest.fn().mockResolvedValue(undefined),
+          withTransaction: jest.fn(
+            /**
+             * Mock transaction handler
+             * @param {() => Promise<void>} fn
+             */
+            async (fn) => fn()
+          )
+        })
+      }
+    },
+
+    prepareDb() {
+      isPrepared = true
+      return Promise.resolve()
+    }
+  }
+})
 
 describe('repository helpers', () => {
   const pageId = '0d174e6c-6131-4588-80bc-684238e13096'
@@ -81,6 +134,30 @@ describe('repository helpers', () => {
         pages: [questionPageWithComponent]
       })
       expect(findComponent(definition, pageId, componentId)).toEqual(component)
+    })
+  })
+
+  describe('removeById', () => {
+    beforeEach(() => {
+      jest.mocked(db.collection).mockReturnValue(mockCollection)
+    })
+
+    it('should remove', async () => {
+      mockCollection.deleteOne.mockResolvedValue({ deletedCount: 1 })
+      await removeById(mockSession, 'my-collection', collectionId)
+      const [filter] = mockCollection.deleteOne.mock.calls[0]
+      expect(filter).toEqual({
+        _id: new ObjectId(collectionId)
+      })
+    })
+
+    it('should throw if not deleted', async () => {
+      mockCollection.deleteOne.mockResolvedValue({ deletedCount: 0 })
+      await expect(
+        removeById(mockSession, 'my-collection', collectionId)
+      ).rejects.toThrow(
+        "Failed to delete id '111bd1111222fe1b33333ccc' from 'my-collection'. Expected deleted count of 1, received 0"
+      )
     })
   })
 })

--- a/src/api/forms/repositories/helpers.test.js
+++ b/src/api/forms/repositories/helpers.test.js
@@ -1,4 +1,4 @@
-import { ApiErrorFunctionCode } from '@defra/forms-model'
+import { ApiErrorCode } from '@defra/forms-model'
 import { ObjectId } from 'mongodb'
 
 import {
@@ -222,7 +222,7 @@ describe('repository helpers', () => {
           definition1,
           '/page-two',
           'Duplicate page path found',
-          ApiErrorFunctionCode.DuplicatePagePathPage,
+          ApiErrorCode.DuplicatePagePathPage,
           'p2'
         )
       }).not.toThrow()

--- a/src/api/forms/service/page.js
+++ b/src/api/forms/service/page.js
@@ -1,4 +1,4 @@
-import { ApiErrorFunctionCode, Engine, FormStatus } from '@defra/forms-model'
+import { ApiErrorCode, Engine, FormStatus } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
@@ -43,7 +43,7 @@ export async function createPageOnDraftDefinition(formId, newPage, author) {
     formDraftDefinition,
     newPage.path,
     `Duplicate page path on Form ID ${formId}`,
-    ApiErrorFunctionCode.DuplicatePagePathQuestion
+    ApiErrorCode.DuplicatePagePathComponent
   )
 
   const { summaryExists } = await repositionSummaryPipeline(
@@ -152,7 +152,7 @@ export async function patchFieldsOnDraftDefinitionPage(
         formDraftDefinition,
         pageFieldsToUpdate.path,
         `Duplicate page path on Form ID ${formId}`,
-        ApiErrorFunctionCode.DuplicatePagePathPage,
+        ApiErrorCode.DuplicatePagePathPage,
         pageId
       )
     }

--- a/src/api/forms/service/page.js
+++ b/src/api/forms/service/page.js
@@ -1,4 +1,4 @@
-import { Engine, FormStatus } from '@defra/forms-model'
+import { ApiErrorFunctionCode, Engine, FormStatus } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 
 import * as formDefinition from '~/src/api/forms/repositories/form-definition-repository.js'
@@ -42,7 +42,8 @@ export async function createPageOnDraftDefinition(formId, newPage, author) {
   uniquePathGate(
     formDraftDefinition,
     newPage.path,
-    `Duplicate page path on Form ID ${formId}`
+    `Duplicate page path on Form ID ${formId}`,
+    ApiErrorFunctionCode.DuplicatePagePathQuestion
   )
 
   const { summaryExists } = await repositionSummaryPipeline(
@@ -139,6 +140,22 @@ export async function patchFieldsOnDraftDefinitionPage(
   try {
     // Check that page exists
     await getFormDefinitionPage(formId, pageId, session)
+
+    if (pageFieldsToUpdate.path) {
+      /** @type {FormDefinition} */
+      const formDraftDefinition = await getFormDefinition(
+        formId,
+        FormStatus.Draft
+      )
+
+      uniquePathGate(
+        formDraftDefinition,
+        pageFieldsToUpdate.path,
+        `Duplicate page path on Form ID ${formId}`,
+        ApiErrorFunctionCode.DuplicatePagePathPage,
+        pageId
+      )
+    }
 
     await session.withTransaction(
       async () => {

--- a/src/api/forms/service/page.test.js
+++ b/src/api/forms/service/page.test.js
@@ -315,6 +315,36 @@ describe('Page service', () => {
         )
       ).rejects.toThrow(Boom.notFound('Duplicate page path on Form ID 123'))
     })
+
+    it('should not fail if not updating path', async () => {
+      const pageOne = buildQuestionPage({
+        id: 'p1',
+        path: '/page-one'
+      })
+      const pageTwo = buildQuestionPage({
+        id: 'p2',
+        path: '/page-two'
+      })
+      const definition1 = buildDefinition({
+        ...definition,
+        pages: [pageOne, pageTwo]
+      })
+
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(definition1)
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(definition1)
+
+      const pageFieldsForConflict = /** @satisfies {PatchPageFields} */ {
+        title: 'Updated Title'
+      }
+
+      const res = await patchFieldsOnDraftDefinitionPage(
+        '123',
+        'p2',
+        pageFieldsForConflict,
+        author
+      )
+      expect(res).toBeDefined()
+    })
   })
 
   describe('deletePageOnDraftDefinition', () => {

--- a/src/api/forms/service/page.test.js
+++ b/src/api/forms/service/page.test.js
@@ -221,6 +221,11 @@ describe('Page service', () => {
           pages: [expectedPage, summaryPage]
         })
       )
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(
+        buildDefinition({
+          pages: [expectedPage, summaryPage]
+        })
+      )
       const page = await patchFieldsOnDraftDefinitionPage(
         '123',
         pageId,
@@ -252,13 +257,18 @@ describe('Page service', () => {
       expect(calledPageId).toBe(pageId)
       expect(pageFieldsToUpdate).toEqual(pageFields)
 
-      expect(dbDefinitionGetSpy.mock.calls[1][2]).toMatchObject({
+      expect(dbDefinitionGetSpy.mock.calls[2][2]).toMatchObject({
         withTransaction: expect.anything()
       })
     })
 
     it('should fail if the page does not exist', async () => {
       jest.mocked(formDefinition.get).mockResolvedValueOnce(initialDefinition)
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(
+        buildDefinition({
+          pages: []
+        })
+      )
       jest.mocked(formDefinition.get).mockResolvedValueOnce(
         buildDefinition({
           pages: []

--- a/src/api/forms/service/page.test.js
+++ b/src/api/forms/service/page.test.js
@@ -283,6 +283,38 @@ describe('Page service', () => {
         )
       )
     })
+
+    it('should fail if updating to duplicate path', async () => {
+      const pageOne = buildQuestionPage({
+        id: 'p1',
+        path: '/page-one'
+      })
+      const pageTwo = buildQuestionPage({
+        id: 'p2',
+        path: '/page-two'
+      })
+      const definition1 = buildDefinition({
+        ...definition,
+        pages: [pageOne, pageTwo]
+      })
+
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(definition1)
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(definition1)
+
+      const pageFieldsForConflict = /** @satisfies {PatchPageFields} */ {
+        title: 'Updated Title',
+        path: '/page-one'
+      }
+
+      await expect(
+        patchFieldsOnDraftDefinitionPage(
+          '123',
+          'p2',
+          pageFieldsForConflict,
+          author
+        )
+      ).rejects.toThrow(Boom.notFound('Duplicate page path on Form ID 123'))
+    })
   })
 
   describe('deletePageOnDraftDefinition', () => {

--- a/src/plugins/transform-errors.js
+++ b/src/plugins/transform-errors.js
@@ -17,6 +17,9 @@ export const transformErrors = {
           response.output.payload.statusCode = response.statusCode
           response.output.payload.message = response.message
           response.output.payload.error = response.name
+        } else {
+          // Allow custom payload in addition to standard Boom properties
+          response.output.payload.data = response.data
         }
       }
 

--- a/src/plugins/transform-errors.js
+++ b/src/plugins/transform-errors.js
@@ -19,7 +19,7 @@ export const transformErrors = {
           response.output.payload.error = response.name
         } else {
           // Allow custom payload in addition to standard Boom properties
-          response.output.payload.data = response.data
+          response.output.payload.custom = response.data
         }
       }
 

--- a/src/routes/forms.test.js
+++ b/src/routes/forms.test.js
@@ -1189,7 +1189,7 @@ describe('Forms route', () => {
           keys: ['0', ''],
           source: 'payload'
         },
-        data: {
+        custom: {
           defaultError: expect.anything()
         }
       })

--- a/src/routes/forms.test.js
+++ b/src/routes/forms.test.js
@@ -1188,6 +1188,9 @@ describe('Forms route', () => {
         validation: {
           keys: ['0', ''],
           source: 'payload'
+        },
+        data: {
+          defaultError: expect.anything()
         }
       })
     })


### PR DESCRIPTION
Uses updated model to reference ApiErrorCodes to match error conditions based on an error code, rather than relying on some text within an error message
Added optional custom payload to Boom errors to present 'errorCode' to the consumer