### PR TITLE
Feature 532794: support v2 schema when updating draft definition

### DIFF
--- a/src/api/forms/service/definition.js
+++ b/src/api/forms/service/definition.js
@@ -66,6 +66,8 @@ export async function updateDraftFormDefinition(formId, definition, author) {
 
     try {
       await session.withTransaction(async () => {
+        logger.info(`Updating form definition (draft) for form ID ${formId}`)
+
         await formDefinition.update(formId, definition, session, schema)
         await formMetadata.updateAudit(formId, author, session)
       })

--- a/src/api/forms/service/definition.test.js
+++ b/src/api/forms/service/definition.test.js
@@ -1,4 +1,9 @@
-import { Engine, FormStatus, formDefinitionSchema } from '@defra/forms-model'
+import {
+  Engine,
+  FormStatus,
+  formDefinitionSchema,
+  formDefinitionV2Schema
+} from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 import { pino } from 'pino'
@@ -956,6 +961,88 @@ describe('Forms service', () => {
 
       expect(formDefinitionCustomisedTitle.name).toBe(
         formMetadataDocument.title
+      )
+    })
+
+    it('should use V2 schema when form definition has engine V2', async () => {
+      const v2FormDefinition = {
+        ...emptyFormWithSummary(),
+        engine: Engine.V2,
+        schema: 2
+      }
+
+      const updateSpy = jest.spyOn(formDefinition, 'update')
+
+      await updateDraftFormDefinition('123', v2FormDefinition, author)
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        '123',
+        {
+          ...v2FormDefinition,
+          name: formMetadataDocument.title
+        },
+        expect.anything(),
+        formDefinitionV2Schema
+      )
+    })
+
+    it('should use V2 schema when form definition has schema version 2', async () => {
+      const v2FormDefinition = {
+        ...emptyFormWithSummary(),
+        schema: 2
+      }
+
+      const updateSpy = jest.spyOn(formDefinition, 'update')
+
+      await updateDraftFormDefinition('123', v2FormDefinition, author)
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        '123',
+        {
+          ...v2FormDefinition,
+          name: formMetadataDocument.title
+        },
+        expect.anything(),
+        formDefinitionV2Schema
+      )
+    })
+
+    it('should use V1 schema when form definition has schema version 1', async () => {
+      const v1FormDefinition = {
+        ...emptyFormWithSummary(),
+        schema: 1
+      }
+
+      const updateSpy = jest.spyOn(formDefinition, 'update')
+
+      await updateDraftFormDefinition('123', v1FormDefinition, author)
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        '123',
+        {
+          ...v1FormDefinition,
+          name: formMetadataDocument.title
+        },
+        expect.anything(),
+        formDefinitionSchema
+      )
+    })
+
+    it('should use V1 schema by default when no engine or schema specified', async () => {
+      const defaultFormDefinition = emptyFormWithSummary()
+
+      const updateSpy = jest.spyOn(formDefinition, 'update')
+
+      await updateDraftFormDefinition('123', defaultFormDefinition, author)
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        '123',
+        {
+          ...defaultFormDefinition,
+          name: formMetadataDocument.title
+        },
+        expect.anything(),
+        formDefinitionSchema
       )
     })
 

--- a/src/api/forms/service/definition.test.js
+++ b/src/api/forms/service/definition.test.js
@@ -964,29 +964,7 @@ describe('Forms service', () => {
       )
     })
 
-    it('should use V2 schema when form definition has engine V2', async () => {
-      const v2FormDefinition = {
-        ...emptyFormWithSummary(),
-        engine: Engine.V2,
-        schema: 2
-      }
-
-      const updateSpy = jest.spyOn(formDefinition, 'update')
-
-      await updateDraftFormDefinition('123', v2FormDefinition, author)
-
-      expect(updateSpy).toHaveBeenCalledWith(
-        '123',
-        {
-          ...v2FormDefinition,
-          name: formMetadataDocument.title
-        },
-        expect.anything(),
-        formDefinitionV2Schema
-      )
-    })
-
-    it('should use V2 schema when form definition has schema version 2', async () => {
+    it('should use V2 schema when form definition has schema version 2 (regardless of engine)', async () => {
       const v2FormDefinition = {
         ...emptyFormWithSummary(),
         schema: 2
@@ -1043,6 +1021,28 @@ describe('Forms service', () => {
         },
         expect.anything(),
         formDefinitionSchema
+      )
+    })
+
+    it('should use V2 schema even with engine V1 if schema is 2', async () => {
+      const v2SchemaV1Engine = {
+        ...emptyFormWithSummary(),
+        engine: Engine.V1,
+        schema: 2
+      }
+
+      const updateSpy = jest.spyOn(formDefinition, 'update')
+
+      await updateDraftFormDefinition('123', v2SchemaV1Engine, author)
+
+      expect(updateSpy).toHaveBeenCalledWith(
+        '123',
+        {
+          ...v2SchemaV1Engine,
+          name: formMetadataDocument.title
+        },
+        expect.anything(),
+        formDefinitionV2Schema
       )
     })
 

--- a/src/api/forms/service/definition.test.js
+++ b/src/api/forms/service/definition.test.js
@@ -1024,28 +1024,6 @@ describe('Forms service', () => {
       )
     })
 
-    it('should use V2 schema even with engine V1 if schema is 2', async () => {
-      const v2SchemaV1Engine = {
-        ...emptyFormWithSummary(),
-        engine: Engine.V1,
-        schema: 2
-      }
-
-      const updateSpy = jest.spyOn(formDefinition, 'update')
-
-      await updateDraftFormDefinition('123', v2SchemaV1Engine, author)
-
-      expect(updateSpy).toHaveBeenCalledWith(
-        '123',
-        {
-          ...v2SchemaV1Engine,
-          name: formMetadataDocument.title
-        },
-        expect.anything(),
-        formDefinitionV2Schema
-      )
-    })
-
     test('should check if form update DB operation is called with correct form data', async () => {
       const dbSpy = jest.spyOn(formMetadata, 'updateAudit')
 

--- a/src/api/forms/service/helpers/definition.js
+++ b/src/api/forms/service/helpers/definition.js
@@ -1,5 +1,24 @@
+import {
+  Engine,
+  SchemaVersion,
+  formDefinitionSchema,
+  formDefinitionV2Schema
+} from '@defra/forms-model'
+
 import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import { logger } from '~/src/api/forms/service/shared.js'
+
+/**
+ * Determines the correct validation schema based on the form definition
+ * @param {FormDefinition} definition
+ * @returns {ObjectSchema<FormDefinition>}
+ */
+export function getValidationSchema(definition) {
+  return definition.engine === Engine.V2 ||
+    definition.schema === SchemaVersion.V2
+    ? formDefinitionV2Schema
+    : formDefinitionSchema
+}
 
 /**
  * Validates the form definition

--- a/src/api/forms/service/helpers/definition.js
+++ b/src/api/forms/service/helpers/definition.js
@@ -1,5 +1,4 @@
 import {
-  Engine,
   SchemaVersion,
   formDefinitionSchema,
   formDefinitionV2Schema
@@ -9,15 +8,20 @@ import { InvalidFormDefinitionError } from '~/src/api/forms/errors.js'
 import { logger } from '~/src/api/forms/service/shared.js'
 
 /**
- * Determines the correct validation schema based on the form definition
+ * Determines the correct validation schema based on the form definition's schema property
  * @param {FormDefinition} definition
  * @returns {ObjectSchema<FormDefinition>}
  */
 export function getValidationSchema(definition) {
-  return definition.engine === Engine.V2 ||
-    definition.schema === SchemaVersion.V2
-    ? formDefinitionV2Schema
-    : formDefinitionSchema
+  const { schema } = definition
+
+  // If schema is explicitly V2, use V2 validation
+  if (schema === SchemaVersion.V2) {
+    return formDefinitionV2Schema
+  }
+
+  // Default to V1 validation (for schema V1 or undefined)
+  return formDefinitionSchema
 }
 
 /**

--- a/src/api/forms/service/helpers/definition.test.js
+++ b/src/api/forms/service/helpers/definition.test.js
@@ -1,5 +1,4 @@
 import {
-  Engine,
   SchemaVersion,
   formDefinitionSchema,
   formDefinitionV2Schema
@@ -14,13 +13,10 @@ import {
 
 describe('definition helpers', () => {
   describe('getValidationSchema', () => {
-    it('should return V2 schema when engine is V2', () => {
-      const definition = buildDefinition({
-        engine: Engine.V2,
-        schema: SchemaVersion.V1
-      })
+    it('should return V1 schema when schema is V1', () => {
+      const definition = buildDefinition({ schema: SchemaVersion.V1 })
       const result = getValidationSchema(definition)
-      expect(result).toBe(formDefinitionV2Schema)
+      expect(result).toBe(formDefinitionSchema)
     })
 
     it('should return V2 schema when schema is V2', () => {
@@ -29,38 +25,14 @@ describe('definition helpers', () => {
       expect(result).toBe(formDefinitionV2Schema)
     })
 
-    it('should return V2 schema when both engine is V2 and schema is V2', () => {
-      const definition = buildDefinition({
-        engine: Engine.V2,
-        schema: SchemaVersion.V2
-      })
-      const result = getValidationSchema(definition)
-      expect(result).toBe(formDefinitionV2Schema)
-    })
-
-    it('should return V1 schema when schema is V1', () => {
-      const definition = buildDefinition({ schema: SchemaVersion.V1 })
-      const result = getValidationSchema(definition)
-      expect(result).toBe(formDefinitionSchema)
-    })
-
-    it('should return V1 schema when engine is V1', () => {
-      const definition = buildDefinition({ engine: Engine.V1 })
-      const result = getValidationSchema(definition)
-      expect(result).toBe(formDefinitionSchema)
-    })
-
-    it('should return V1 schema by default when no engine or schema specified', () => {
+    it('should return V1 schema by default when no schema specified', () => {
       const definition = buildDefinition({})
       const result = getValidationSchema(definition)
       expect(result).toBe(formDefinitionSchema)
     })
 
-    it('should return V1 schema when engine is V1 and schema is V1', () => {
-      const definition = buildDefinition({
-        engine: Engine.V1,
-        schema: SchemaVersion.V1
-      })
+    it('should return V1 schema when schema is undefined', () => {
+      const definition = buildDefinition({ schema: undefined })
       const result = getValidationSchema(definition)
       expect(result).toBe(formDefinitionSchema)
     })

--- a/src/models/forms.js
+++ b/src/models/forms.js
@@ -1,6 +1,7 @@
 import {
   componentSchema,
   formDefinitionSchema,
+  formDefinitionV2Schema,
   formMetadataInputSchema,
   idSchema,
   listSchemaV2,
@@ -85,8 +86,10 @@ export const createFormSchema = Joi.object().keys({
   teamEmail: formMetadataInputSchema.extract('teamEmail')
 })
 
-// Update form definition schema
-export const updateFormDefinitionSchema = formDefinitionSchema
+export const updateFormDefinitionSchema = Joi.alternatives().try(
+  formDefinitionSchema, // V1 forms (schema: 1)
+  formDefinitionV2Schema // V2 forms (schema: 2)
+)
 
 export const migrateDefinitionParamSchema = Joi.object()
   .keys({

--- a/src/models/forms.test.js
+++ b/src/models/forms.test.js
@@ -1,6 +1,7 @@
-import { Engine, SchemaVersion } from '@defra/forms-model'
+import { ControllerType, Engine, SchemaVersion } from '@defra/forms-model'
 import { ValidationError } from 'joi'
 
+import { buildDefinition } from '~/src/api/forms/__stubs__/definition.js'
 import {
   sortIdsSchema,
   updateFormDefinitionSchema
@@ -41,26 +42,11 @@ describe('forms model', () => {
   describe('updateFormDefinitionSchema', () => {
     describe('V1 form definitions', () => {
       it('should accept valid V1 form definition with schema 1', () => {
-        const v1FormDefinition = {
+        const v1FormDefinition = buildDefinition({
           name: 'Test Form V1',
           schema: 1,
-          startPage: '/summary',
-          pages: [
-            {
-              title: 'Summary',
-              path: '/summary',
-              controller: 'SummaryPageController'
-            }
-          ],
-          conditions: [],
-          sections: [
-            {
-              name: 'section',
-              title: 'Section title'
-            }
-          ],
-          lists: []
-        }
+          startPage: '/summary'
+        })
 
         const result = updateFormDefinitionSchema.validate(v1FormDefinition)
         expect(result.error).toBeUndefined()
@@ -70,25 +56,10 @@ describe('forms model', () => {
       })
 
       it('should accept valid V1 form definition without schema property', () => {
-        const v1FormDefinition = {
+        const v1FormDefinition = buildDefinition({
           name: 'Test Form V1',
-          startPage: '/summary',
-          pages: [
-            {
-              title: 'Summary',
-              path: '/summary',
-              controller: 'SummaryPageController'
-            }
-          ],
-          conditions: [],
-          sections: [
-            {
-              name: 'section',
-              title: 'Section title'
-            }
-          ],
-          lists: []
-        }
+          startPage: '/summary'
+        })
 
         const result = updateFormDefinitionSchema.validate(v1FormDefinition)
         expect(result.error).toBeUndefined()
@@ -97,26 +68,11 @@ describe('forms model', () => {
       })
 
       it('should accept valid V1 form definition without engine property', () => {
-        const v1FormDefinition = {
+        const v1FormDefinition = buildDefinition({
           name: 'Test Form V1',
           schema: 1,
-          startPage: '/summary',
-          pages: [
-            {
-              title: 'Summary',
-              path: '/summary',
-              controller: 'SummaryPageController'
-            }
-          ],
-          conditions: [],
-          sections: [
-            {
-              name: 'section',
-              title: 'Section title'
-            }
-          ],
-          lists: []
-        }
+          startPage: '/summary'
+        })
 
         const result = updateFormDefinitionSchema.validate(v1FormDefinition)
         expect(result.error).toBeUndefined()
@@ -127,7 +83,7 @@ describe('forms model', () => {
 
     describe('V2 form definitions', () => {
       it('should accept valid V2 form definition with schema 2', () => {
-        const v2FormDefinition = {
+        const v2FormDefinition = buildDefinition({
           name: 'Test Form V2',
           schema: 2,
           engine: Engine.V2,
@@ -137,18 +93,10 @@ describe('forms model', () => {
               id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
               title: 'Summary',
               path: '/summary',
-              controller: 'SummaryPageController'
+              controller: ControllerType.Summary
             }
-          ],
-          conditions: [],
-          sections: [
-            {
-              name: 'section',
-              title: 'Section title'
-            }
-          ],
-          lists: []
-        }
+          ]
+        })
 
         const result = updateFormDefinitionSchema.validate(v2FormDefinition)
         expect(result.error).toBeUndefined()
@@ -158,7 +106,7 @@ describe('forms model', () => {
       })
 
       it('should accept valid V2 form definition with SchemaVersion.V2', () => {
-        const v2FormDefinition = {
+        const v2FormDefinition = buildDefinition({
           name: 'Test Form V2',
           schema: SchemaVersion.V2,
           engine: Engine.V2,
@@ -168,18 +116,10 @@ describe('forms model', () => {
               id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
               title: 'Summary',
               path: '/summary',
-              controller: 'SummaryPageController'
+              controller: ControllerType.Summary
             }
-          ],
-          conditions: [],
-          sections: [
-            {
-              name: 'section',
-              title: 'Section title'
-            }
-          ],
-          lists: []
-        }
+          ]
+        })
 
         const result = updateFormDefinitionSchema.validate(v2FormDefinition)
         expect(result.error).toBeUndefined()
@@ -189,7 +129,7 @@ describe('forms model', () => {
       })
 
       it('should accept V2 form definition with engine V2 but no schema property', () => {
-        const v2FormDefinition = {
+        const v2FormDefinition = buildDefinition({
           name: 'Test Form V2',
           engine: Engine.V2,
           startPage: '/summary',
@@ -198,18 +138,10 @@ describe('forms model', () => {
               id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
               title: 'Summary',
               path: '/summary',
-              controller: 'SummaryPageController'
+              controller: ControllerType.Summary
             }
-          ],
-          conditions: [],
-          sections: [
-            {
-              name: 'section',
-              title: 'Section title'
-            }
-          ],
-          lists: []
-        }
+          ]
+        })
 
         const result = updateFormDefinitionSchema.validate(v2FormDefinition)
         expect(result.error).toBeUndefined()
@@ -221,14 +153,13 @@ describe('forms model', () => {
 
     describe('Mixed and edge cases', () => {
       it('should reject form definition with invalid schema version', () => {
+        /** @type {any} */
         const invalidFormDefinition = {
-          name: 'Test Form',
-          schema: 999, // Invalid schema version
-          startPage: '/summary',
-          pages: [],
-          conditions: [],
-          sections: [],
-          lists: []
+          ...buildDefinition({
+            name: 'Test Form',
+            startPage: '/summary'
+          }),
+          schema: 999 // Invalid schema version
         }
 
         const result = updateFormDefinitionSchema.validate(
@@ -242,14 +173,12 @@ describe('forms model', () => {
 
       it('should reject form definition with invalid properties', () => {
         const invalidFormDefinition = {
-          name: 'Test Form',
-          schema: 1,
-          invalidProperty: 'should not be allowed',
-          startPage: '/summary',
-          pages: [],
-          conditions: [],
-          sections: [],
-          lists: []
+          ...buildDefinition({
+            name: 'Test Form',
+            schema: 1,
+            startPage: '/summary'
+          }),
+          invalidProperty: 'should not be allowed'
         }
 
         const result = updateFormDefinitionSchema.validate(
@@ -273,23 +202,13 @@ describe('forms model', () => {
     describe('Joi.alternatives() behavior', () => {
       it('should try V1 schema first and fall back to V2 schema', () => {
         // This test verifies that the alternatives schema works as expected
-        const v1Form = {
+        const v1Form = buildDefinition({
           name: 'V1 Form',
           schema: 1,
-          startPage: '/summary',
-          pages: [
-            {
-              title: 'Summary',
-              path: '/summary',
-              controller: 'SummaryPageController'
-            }
-          ],
-          conditions: [],
-          sections: [],
-          lists: []
-        }
+          startPage: '/summary'
+        })
 
-        const v2Form = {
+        const v2Form = buildDefinition({
           name: 'V2 Form',
           schema: 2,
           engine: Engine.V2,
@@ -299,13 +218,10 @@ describe('forms model', () => {
               id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
               title: 'Summary',
               path: '/summary',
-              controller: 'SummaryPageController'
+              controller: ControllerType.Summary
             }
-          ],
-          conditions: [],
-          sections: [],
-          lists: []
-        }
+          ]
+        })
 
         const v1Result = updateFormDefinitionSchema.validate(v1Form)
         const v2Result = updateFormDefinitionSchema.validate(v2Form)

--- a/src/models/forms.test.js
+++ b/src/models/forms.test.js
@@ -1,6 +1,10 @@
+import { Engine, SchemaVersion } from '@defra/forms-model'
 import { ValidationError } from 'joi'
 
-import { sortIdsSchema } from '~/src/models/forms.js'
+import {
+  sortIdsSchema,
+  updateFormDefinitionSchema
+} from '~/src/models/forms.js'
 
 describe('forms model', () => {
   describe('sortIdsSchema', () => {
@@ -31,6 +35,288 @@ describe('forms model', () => {
           ['not-a-valid-uuid']
         )
       )
+    })
+  })
+
+  describe('updateFormDefinitionSchema', () => {
+    describe('V1 form definitions', () => {
+      it('should accept valid V1 form definition with schema 1', () => {
+        const v1FormDefinition = {
+          name: 'Test Form V1',
+          schema: 1,
+          startPage: '/summary',
+          pages: [
+            {
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [
+            {
+              name: 'section',
+              title: 'Section title'
+            }
+          ],
+          lists: []
+        }
+
+        const result = updateFormDefinitionSchema.validate(v1FormDefinition)
+        expect(result.error).toBeUndefined()
+        expect(result.value.name).toBe('Test Form V1')
+        expect(result.value.schema).toBe(1)
+        expect(result.value.startPage).toBe('/summary')
+      })
+
+      it('should accept valid V1 form definition without schema property', () => {
+        const v1FormDefinition = {
+          name: 'Test Form V1',
+          startPage: '/summary',
+          pages: [
+            {
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [
+            {
+              name: 'section',
+              title: 'Section title'
+            }
+          ],
+          lists: []
+        }
+
+        const result = updateFormDefinitionSchema.validate(v1FormDefinition)
+        expect(result.error).toBeUndefined()
+        expect(result.value.name).toBe('Test Form V1')
+        expect(result.value.startPage).toBe('/summary')
+      })
+
+      it('should accept valid V1 form definition without engine property', () => {
+        const v1FormDefinition = {
+          name: 'Test Form V1',
+          schema: 1,
+          startPage: '/summary',
+          pages: [
+            {
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [
+            {
+              name: 'section',
+              title: 'Section title'
+            }
+          ],
+          lists: []
+        }
+
+        const result = updateFormDefinitionSchema.validate(v1FormDefinition)
+        expect(result.error).toBeUndefined()
+        expect(result.value.name).toBe('Test Form V1')
+        expect(result.value.schema).toBe(1)
+      })
+    })
+
+    describe('V2 form definitions', () => {
+      it('should accept valid V2 form definition with schema 2', () => {
+        const v2FormDefinition = {
+          name: 'Test Form V2',
+          schema: 2,
+          engine: Engine.V2,
+          startPage: '/summary',
+          pages: [
+            {
+              id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [
+            {
+              name: 'section',
+              title: 'Section title'
+            }
+          ],
+          lists: []
+        }
+
+        const result = updateFormDefinitionSchema.validate(v2FormDefinition)
+        expect(result.error).toBeUndefined()
+        expect(result.value.name).toBe('Test Form V2')
+        expect(result.value.schema).toBe(2)
+        expect(result.value.engine).toBe(Engine.V2)
+      })
+
+      it('should accept valid V2 form definition with SchemaVersion.V2', () => {
+        const v2FormDefinition = {
+          name: 'Test Form V2',
+          schema: SchemaVersion.V2,
+          engine: Engine.V2,
+          startPage: '/summary',
+          pages: [
+            {
+              id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [
+            {
+              name: 'section',
+              title: 'Section title'
+            }
+          ],
+          lists: []
+        }
+
+        const result = updateFormDefinitionSchema.validate(v2FormDefinition)
+        expect(result.error).toBeUndefined()
+        expect(result.value.name).toBe('Test Form V2')
+        expect(result.value.schema).toBe(SchemaVersion.V2)
+        expect(result.value.engine).toBe(Engine.V2)
+      })
+
+      it('should accept V2 form definition with engine V2 but no schema property', () => {
+        const v2FormDefinition = {
+          name: 'Test Form V2',
+          engine: Engine.V2,
+          startPage: '/summary',
+          pages: [
+            {
+              id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [
+            {
+              name: 'section',
+              title: 'Section title'
+            }
+          ],
+          lists: []
+        }
+
+        const result = updateFormDefinitionSchema.validate(v2FormDefinition)
+        expect(result.error).toBeUndefined()
+        expect(result.value.name).toBe('Test Form V2')
+        expect(result.value.engine).toBe(Engine.V2)
+        // Schema may be set to default value
+      })
+    })
+
+    describe('Mixed and edge cases', () => {
+      it('should reject form definition with invalid schema version', () => {
+        const invalidFormDefinition = {
+          name: 'Test Form',
+          schema: 999, // Invalid schema version
+          startPage: '/summary',
+          pages: [],
+          conditions: [],
+          sections: [],
+          lists: []
+        }
+
+        const result = updateFormDefinitionSchema.validate(
+          invalidFormDefinition
+        )
+        expect(result.error).toBeDefined()
+        expect(result.error?.message).toContain(
+          'does not match any of the allowed types'
+        )
+      })
+
+      it('should reject form definition with invalid properties', () => {
+        const invalidFormDefinition = {
+          name: 'Test Form',
+          schema: 1,
+          invalidProperty: 'should not be allowed',
+          startPage: '/summary',
+          pages: [],
+          conditions: [],
+          sections: [],
+          lists: []
+        }
+
+        const result = updateFormDefinitionSchema.validate(
+          invalidFormDefinition
+        )
+        expect(result.error).toBeDefined()
+      })
+
+      it('should reject form definition with missing required fields', () => {
+        const invalidFormDefinition = {
+          // Missing required fields
+        }
+
+        const result = updateFormDefinitionSchema.validate(
+          invalidFormDefinition
+        )
+        expect(result.error).toBeDefined()
+      })
+    })
+
+    describe('Joi.alternatives() behavior', () => {
+      it('should try V1 schema first and fall back to V2 schema', () => {
+        // This test verifies that the alternatives schema works as expected
+        const v1Form = {
+          name: 'V1 Form',
+          schema: 1,
+          startPage: '/summary',
+          pages: [
+            {
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [],
+          lists: []
+        }
+
+        const v2Form = {
+          name: 'V2 Form',
+          schema: 2,
+          engine: Engine.V2,
+          startPage: '/summary',
+          pages: [
+            {
+              id: '449a45f6-4541-4a46-91bd-8b8931b07b50',
+              title: 'Summary',
+              path: '/summary',
+              controller: 'SummaryPageController'
+            }
+          ],
+          conditions: [],
+          sections: [],
+          lists: []
+        }
+
+        const v1Result = updateFormDefinitionSchema.validate(v1Form)
+        const v2Result = updateFormDefinitionSchema.validate(v2Form)
+
+        expect(v1Result.error).toBeUndefined()
+        expect(v2Result.error).toBeUndefined()
+        expect(v1Result.value.name).toBe('V1 Form')
+        expect(v2Result.value.name).toBe('V2 Form')
+        expect(v1Result.value.schema).toBe(1)
+        expect(v2Result.value.schema).toBe(2)
+      })
     })
   })
 })


### PR DESCRIPTION
## Story Link
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/532794

## Description
This PR fixes the forms manager API to properly support V2 schema validation when updating draft form definitions. Prior to this, the POST /forms/{id}/definition/draft endpoint was hardcoded to use V1 schema validation for all uploads, causing V2 forms with `"schema": 2` to be rejected with the error "schema" must be [1]. Here we're implementing dynamic schema selection logic that uses V2 validation for forms with schema: 2 and defaults to V1 for all other cases.