### PR TITLE
Fixed summary page missing components array

### DIFF
--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -493,6 +493,13 @@ export function modifyAddComponent(definition, pageId, component, position) {
   const idx = getPageIndex(definition, pageId)
   const page = definition.pages[idx]
 
+  if (
+    !hasComponentsEvenIfNoNext(page) &&
+    page.controller === ControllerType.Summary
+  ) {
+    page.components = []
+  }
+
   if (hasComponentsEvenIfNoNext(page)) {
     if (position === undefined) {
       page.components.push(component)

--- a/src/api/forms/repositories/helpers.test.js
+++ b/src/api/forms/repositories/helpers.test.js
@@ -780,6 +780,28 @@ describe('repository helpers', () => {
         newComponent
       )
     })
+    it('should add the component if summary page and components property doesnt yet exist', () => {
+      const definition = buildDefinition({
+        pages: [summaryPage]
+      })
+
+      const newComponent = buildTextFieldComponent({
+        name: 'abcdef'
+      })
+      const modified = modifyAddComponent(
+        definition,
+        summaryPage.id ?? '',
+        newComponent,
+        0
+      )
+
+      const page = modified.pages.at(0)
+      expect(hasComponentsEvenIfNoNext(page)).toBe(true)
+      expect(hasComponentsEvenIfNoNext(page) && page.components).toHaveLength(1)
+      expect(hasComponentsEvenIfNoNext(page) && page.components.at(0)).toBe(
+        newComponent
+      )
+    })
   })
 
   describe('modifyUpdateComponent', () => {


### PR DESCRIPTION
Saving declaration text to a summary page ('check your answers' page) was silently failing.
This fixes the issue by creating an empty components array (if it is missing) prior to adding the new component.
The fix only creates the empty array for summary pages.