### PR TITLE
feat DF-59: allow deleting condition(s) associated with page

### DIFF
--- a/src/api/forms/repositories/form-definition-repository.js
+++ b/src/api/forms/repositories/form-definition-repository.js
@@ -21,6 +21,7 @@ import {
   modifyEngineVersion,
   modifyName,
   modifyReorderPages,
+  modifyUnassignCondition,
   modifyUpdateComponent,
   modifyUpdateCondition,
   modifyUpdateList,
@@ -525,14 +526,7 @@ export async function deleteCondition(formId, conditionId, session) {
 
   /** @type {UpdateCallback} */
   const callback = (draft) => {
-    draft.pages.forEach((page) => {
-      if (page.condition === conditionId) {
-        logger.info(
-          `Unassigning condition ${conditionId} from page ${page.id ?? 'unknown'}`
-        )
-        delete page.condition
-      }
-    })
+    modifyUnassignCondition(draft, conditionId)
 
     return modifyDeleteCondition(draft, conditionId)
   }

--- a/src/api/forms/repositories/form-definition-repository.js
+++ b/src/api/forms/repositories/form-definition-repository.js
@@ -515,7 +515,7 @@ export async function updateCondition(formId, conditionId, condition, session) {
 }
 
 /**
- * Removes a condition by id
+ * Removes a condition by id and unassigns it from any pages that use it
  * @param {string} formId
  * @param {string} conditionId
  * @param {ClientSession} session
@@ -524,7 +524,18 @@ export async function deleteCondition(formId, conditionId, session) {
   logger.info(`Deleting condition ID ${conditionId} on form ID ${formId}`)
 
   /** @type {UpdateCallback} */
-  const callback = (draft) => modifyDeleteCondition(draft, conditionId)
+  const callback = (draft) => {
+    draft.pages.forEach((page) => {
+      if (page.condition === conditionId) {
+        logger.info(
+          `Unassigning condition ${conditionId} from page ${page.id ?? 'unknown'}`
+        )
+        delete page.condition
+      }
+    })
+
+    return modifyDeleteCondition(draft, conditionId)
+  }
 
   await modifyDraft(formId, callback, session)
 

--- a/src/api/forms/repositories/helpers.js
+++ b/src/api/forms/repositories/helpers.js
@@ -10,7 +10,10 @@ import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
 
 import { validate } from '~/src/api/forms/service/helpers/definition.js'
+import { createLogger } from '~/src/helpers/logging/logger.js'
 import { DEFINITION_COLLECTION_NAME, db } from '~/src/mongo.js'
+
+const logger = createLogger()
 
 /**
  * Removes a row in a MongoDB collection by its unique ID and fail if not completed.
@@ -656,6 +659,25 @@ export function modifyDeleteCondition(definition, conditionId) {
   const idx = getConditionIndex(definition, conditionId)
 
   definition.conditions.splice(idx, 1)
+
+  return definition
+}
+
+/**
+ * Unassigns a condition from all pages that reference it
+ * @param {FormDefinition} definition
+ * @param {string} conditionId
+ * @returns {FormDefinition}
+ */
+export function modifyUnassignCondition(definition, conditionId) {
+  definition.pages.forEach((page) => {
+    if (page.condition === conditionId) {
+      logger.info(
+        `Unassigning condition ${conditionId} from page ${page.id ?? 'unknown'}`
+      )
+      delete page.condition
+    }
+  })
 
   return definition
 }

--- a/src/api/forms/repositories/helpers.test.js
+++ b/src/api/forms/repositories/helpers.test.js
@@ -44,6 +44,7 @@ import {
   modifyEngineVersion,
   modifyName,
   modifyReorderPages,
+  modifyUnassignCondition,
   modifyUpdateComponent,
   modifyUpdateList,
   modifyUpdatePage,
@@ -925,6 +926,65 @@ describe('repository helpers', () => {
       const modified = modifyDeleteList(definition, listId)
 
       expect(modified.lists).toHaveLength(0)
+    })
+  })
+
+  describe('modifyUnassignCondition', () => {
+    it('should unassign condition from pages that reference it', () => {
+      const pageWithCondition = buildQuestionPage({
+        id: 'page-with-condition',
+        condition: conditionId
+      })
+      const pageWithDifferentCondition = buildQuestionPage({
+        id: 'page-with-different-condition',
+        condition: 'different-condition-id'
+      })
+      const pageWithoutCondition = buildQuestionPage({
+        id: 'page-without-condition'
+      })
+
+      const definition = buildDefinition({
+        pages: [
+          pageWithCondition,
+          pageWithDifferentCondition,
+          pageWithoutCondition
+        ],
+        conditions
+      })
+
+      const modified = modifyUnassignCondition(definition, conditionId)
+
+      expect(modified.pages[0].condition).toBeUndefined()
+      expect(modified.pages[1].condition).toBe('different-condition-id')
+      expect(modified.pages[2].condition).toBeUndefined()
+    })
+
+    it('should handle pages without IDs gracefully', () => {
+      const pageWithoutId = buildQuestionPage({
+        title: 'Page without ID',
+        condition: conditionId
+      })
+      delete pageWithoutId.id
+
+      const definition = buildDefinition({
+        pages: [pageWithoutId],
+        conditions
+      })
+
+      const modified = modifyUnassignCondition(definition, conditionId)
+
+      expect(modified.pages[0].condition).toBeUndefined()
+    })
+
+    it('should return the modified definition', () => {
+      const definition = buildDefinition({
+        pages: [questionPageWithComponent],
+        conditions
+      })
+
+      const result = modifyUnassignCondition(definition, conditionId)
+
+      expect(result).toBe(definition)
     })
   })
 })


### PR DESCRIPTION
## Story Link
https://eaflood.atlassian.net/browse/DF-59?atlOrigin=eyJpIjoiY2VjZTAyM2E5MDQ1NDljNmFlMDUwYTIxNTE2ODIxZDIiLCJwIjoiaiJ9

## Description
This PR introduces the ability to delete a condition that is associated to a page.