### PR TITLE
feature/DF-272-297: Team name and email publish audit messages

### DIFF
--- a/src/messaging/mappers/form-events-bulk.js
+++ b/src/messaging/mappers/form-events-bulk.js
@@ -1,14 +1,19 @@
-import { formOrganisationUpdatedMapper } from '~/src/messaging/mappers/form-events.js'
+import {
+  formOrganisationUpdatedMapper,
+  formTeamNameUpdatedMapper
+} from '~/src/messaging/mappers/form-events.js'
 
 /**
  * @type {Record<string, (function(FormMetadata, PartialFormMetadataDocument): AuditMessage)>}
  */
 const mapperLookup = {
-  organisation: formOrganisationUpdatedMapper
+  organisation: formOrganisationUpdatedMapper,
+  teamName: formTeamNameUpdatedMapper
 }
 
 const validFields = /** @type {(keyof PartialFormMetadataDocument)[]} */ ([
-  'organisation'
+  'organisation',
+  'teamName'
 ])
 
 const validKeys = /** @type {string[]} */ (validFields)

--- a/src/messaging/mappers/form-events-bulk.js
+++ b/src/messaging/mappers/form-events-bulk.js
@@ -1,5 +1,6 @@
 import {
   formOrganisationUpdatedMapper,
+  formTeamEmailUpdatedMapper,
   formTeamNameUpdatedMapper
 } from '~/src/messaging/mappers/form-events.js'
 
@@ -8,12 +9,14 @@ import {
  */
 const mapperLookup = {
   organisation: formOrganisationUpdatedMapper,
-  teamName: formTeamNameUpdatedMapper
+  teamName: formTeamNameUpdatedMapper,
+  teamEmail: formTeamEmailUpdatedMapper
 }
 
 const validFields = /** @type {(keyof PartialFormMetadataDocument)[]} */ ([
   'organisation',
-  'teamName'
+  'teamName',
+  'teamEmail'
 ])
 
 const validKeys = /** @type {string[]} */ (validFields)

--- a/src/messaging/mappers/form-events-bulk.test.js
+++ b/src/messaging/mappers/form-events-bulk.test.js
@@ -85,9 +85,9 @@ describe('publish', () => {
         updatedAt
       })
       const messages = getFormMetadataAuditMessages(metadata, formUpdated)
-      const [formOrgUpdatedMessage] = messages
+      const [formUpdatedMessage] = messages
       expect(messages).toHaveLength(1)
-      expect(formOrgUpdatedMessage).toEqual({
+      expect(formUpdatedMessage).toEqual({
         entityId: formId,
         messageCreatedAt: expect.any(Date),
         schemaVersion: AuditEventMessageSchemaVersion.V1,
@@ -104,6 +104,43 @@ describe('publish', () => {
             },
             new: {
               teamName: 'New team name'
+            }
+          }
+        }
+      })
+    })
+
+    it('should get FORM_TEAM_EMAIL_UPDATED audit message', () => {
+      const updatedAt = new Date('2025-07-27')
+      const updatedBy = {
+        displayName: 'Gandalf',
+        id: '29a8b10d-1d7a-40d4-b312-c57f74e1a606'
+      }
+      const formUpdated = buildPartialFormMetadataDocument({
+        teamEmail: 'newemail@example.com',
+        updatedBy,
+        updatedAt
+      })
+      const messages = getFormMetadataAuditMessages(metadata, formUpdated)
+      const [formUpdatedMessage] = messages
+      expect(messages).toHaveLength(1)
+      expect(formUpdatedMessage).toEqual({
+        entityId: formId,
+        messageCreatedAt: expect.any(Date),
+        schemaVersion: AuditEventMessageSchemaVersion.V1,
+        category: AuditEventMessageCategory.FORM,
+        type: AuditEventMessageType.FORM_TEAM_EMAIL_UPDATED,
+        createdAt: updatedAt,
+        createdBy: updatedBy,
+        data: {
+          formId,
+          slug: 'audit-form',
+          changes: {
+            previous: {
+              teamEmail: 'forms@example.com'
+            },
+            new: {
+              teamEmail: 'newemail@example.com'
             }
           }
         }

--- a/src/messaging/mappers/form-events-bulk.test.js
+++ b/src/messaging/mappers/form-events-bulk.test.js
@@ -72,5 +72,42 @@ describe('publish', () => {
         }
       })
     })
+
+    it('should get FORM_TEAM_NAME_UPDATED audit message', () => {
+      const updatedAt = new Date('2025-07-27')
+      const updatedBy = {
+        displayName: 'Gandalf',
+        id: '29a8b10d-1d7a-40d4-b312-c57f74e1a606'
+      }
+      const formUpdated = buildPartialFormMetadataDocument({
+        teamName: 'New team name',
+        updatedBy,
+        updatedAt
+      })
+      const messages = getFormMetadataAuditMessages(metadata, formUpdated)
+      const [formOrgUpdatedMessage] = messages
+      expect(messages).toHaveLength(1)
+      expect(formOrgUpdatedMessage).toEqual({
+        entityId: formId,
+        messageCreatedAt: expect.any(Date),
+        schemaVersion: AuditEventMessageSchemaVersion.V1,
+        category: AuditEventMessageCategory.FORM,
+        type: AuditEventMessageType.FORM_TEAM_NAME_UPDATED,
+        createdAt: updatedAt,
+        createdBy: updatedBy,
+        data: {
+          formId,
+          slug: 'audit-form',
+          changes: {
+            previous: {
+              teamName: 'Forms'
+            },
+            new: {
+              teamName: 'New team name'
+            }
+          }
+        }
+      })
+    })
   })
 })

--- a/src/messaging/mappers/form-events-bulk.test.js
+++ b/src/messaging/mappers/form-events-bulk.test.js
@@ -85,9 +85,9 @@ describe('publish', () => {
         updatedAt
       })
       const messages = getFormMetadataAuditMessages(metadata, formUpdated)
-      const [formUpdatedMessage] = messages
+      const [formNameUpdatedMessage] = messages
       expect(messages).toHaveLength(1)
-      expect(formUpdatedMessage).toEqual({
+      expect(formNameUpdatedMessage).toEqual({
         entityId: formId,
         messageCreatedAt: expect.any(Date),
         schemaVersion: AuditEventMessageSchemaVersion.V1,
@@ -122,9 +122,68 @@ describe('publish', () => {
         updatedAt
       })
       const messages = getFormMetadataAuditMessages(metadata, formUpdated)
-      const [formUpdatedMessage] = messages
+      const [formEmailUpdatedMessage] = messages
       expect(messages).toHaveLength(1)
-      expect(formUpdatedMessage).toEqual({
+      expect(formEmailUpdatedMessage).toEqual({
+        entityId: formId,
+        messageCreatedAt: expect.any(Date),
+        schemaVersion: AuditEventMessageSchemaVersion.V1,
+        category: AuditEventMessageCategory.FORM,
+        type: AuditEventMessageType.FORM_TEAM_EMAIL_UPDATED,
+        createdAt: updatedAt,
+        createdBy: updatedBy,
+        data: {
+          formId,
+          slug: 'audit-form',
+          changes: {
+            previous: {
+              teamEmail: 'forms@example.com'
+            },
+            new: {
+              teamEmail: 'newemail@example.com'
+            }
+          }
+        }
+      })
+    })
+
+    it('should get FORM_TEAM_NAME_UPDATED and FORM_TEAM_EMAIL_UPDATED audit message', () => {
+      const updatedAt = new Date('2025-07-27')
+      const updatedBy = {
+        displayName: 'Gandalf',
+        id: '29a8b10d-1d7a-40d4-b312-c57f74e1a606'
+      }
+      const formUpdated = buildPartialFormMetadataDocument({
+        teamName: 'New team name',
+        teamEmail: 'newemail@example.com',
+        updatedBy,
+        updatedAt
+      })
+      const messages = getFormMetadataAuditMessages(metadata, formUpdated)
+      const [formNameUpdatedMessage, formEmailUpdatedMessage] = messages
+      expect(messages).toHaveLength(2)
+      expect(formNameUpdatedMessage).toEqual({
+        entityId: formId,
+        messageCreatedAt: expect.any(Date),
+        schemaVersion: AuditEventMessageSchemaVersion.V1,
+        category: AuditEventMessageCategory.FORM,
+        type: AuditEventMessageType.FORM_TEAM_NAME_UPDATED,
+        createdAt: updatedAt,
+        createdBy: updatedBy,
+        data: {
+          formId,
+          slug: 'audit-form',
+          changes: {
+            previous: {
+              teamName: 'Forms'
+            },
+            new: {
+              teamName: 'New team name'
+            }
+          }
+        }
+      })
+      expect(formEmailUpdatedMessage).toEqual({
         entityId: formId,
         messageCreatedAt: expect.any(Date),
         schemaVersion: AuditEventMessageSchemaVersion.V1,

--- a/src/messaging/mappers/form-events.js
+++ b/src/messaging/mappers/form-events.js
@@ -152,6 +152,45 @@ export function formTeamNameUpdatedMapper(metadata, updatedForm) {
 }
 
 /**
- * @import { FormTitleUpdatedMessageData, FormOrganisationUpdatedMessage, FormOrganisationUpdatedMessageData, FormMetadata, FormCreatedMessage, FormCreatedMessageData, FormTitleUpdatedMessage, FormTeamNameUpdatedMessage, FormTeamNameUpdatedMessageData } from '@defra/forms-model'
+ * @param {FormMetadata} metadata
+ * @param {PartialFormMetadataDocument} updatedForm
+ * @returns {FormTeamEmailUpdatedMessage}
+ */
+export function formTeamEmailUpdatedMapper(metadata, updatedForm) {
+  const { teamEmail: oldTeamEmail } = metadata
+  const { teamEmail } = updatedForm
+
+  if (!teamEmail) {
+    throw new Error('Unexpected missing teamEmail')
+  }
+
+  const baseData = createFormMessageDataBase(metadata)
+
+  /**
+   * @type {FormTeamEmailUpdatedMessageData}
+   */
+  const data = {
+    ...baseData,
+    changes: {
+      previous: {
+        teamEmail: oldTeamEmail
+      },
+      new: {
+        teamEmail
+      }
+    }
+  }
+  const auditMessageBase = createV1MessageBase(metadata, updatedForm)
+
+  return {
+    ...auditMessageBase,
+    data,
+    category: AuditEventMessageCategory.FORM,
+    type: AuditEventMessageType.FORM_TEAM_EMAIL_UPDATED
+  }
+}
+
+/**
+ * @import { FormTitleUpdatedMessageData, FormOrganisationUpdatedMessage, FormOrganisationUpdatedMessageData, FormMetadata, FormCreatedMessage, FormCreatedMessageData, FormTitleUpdatedMessage, FormTeamNameUpdatedMessage, FormTeamNameUpdatedMessageData, FormTeamEmailUpdatedMessage, FormTeamEmailUpdatedMessageData } from '@defra/forms-model'
  * @import { PartialFormMetadataDocument } from '~/src/api/types.js'
  */

--- a/src/messaging/mappers/form-events.js
+++ b/src/messaging/mappers/form-events.js
@@ -113,6 +113,45 @@ export function formOrganisationUpdatedMapper(metadata, updatedForm) {
 }
 
 /**
- * @import { FormTitleUpdatedMessageData, FormOrganisationUpdatedMessage, FormOrganisationUpdatedMessageData, FormMetadata, FormCreatedMessage, FormCreatedMessageData, FormTitleUpdatedMessage } from '@defra/forms-model'
+ * @param {FormMetadata} metadata
+ * @param {PartialFormMetadataDocument} updatedForm
+ * @returns {FormTeamNameUpdatedMessage}
+ */
+export function formTeamNameUpdatedMapper(metadata, updatedForm) {
+  const { teamName: oldTeamName } = metadata
+  const { teamName } = updatedForm
+
+  if (!teamName) {
+    throw new Error('Unexpected missing teamName')
+  }
+
+  const baseData = createFormMessageDataBase(metadata)
+
+  /**
+   * @type {FormTeamNameUpdatedMessageData}
+   */
+  const data = {
+    ...baseData,
+    changes: {
+      previous: {
+        teamName: oldTeamName
+      },
+      new: {
+        teamName
+      }
+    }
+  }
+  const auditMessageBase = createV1MessageBase(metadata, updatedForm)
+
+  return {
+    ...auditMessageBase,
+    data,
+    category: AuditEventMessageCategory.FORM,
+    type: AuditEventMessageType.FORM_TEAM_NAME_UPDATED
+  }
+}
+
+/**
+ * @import { FormTitleUpdatedMessageData, FormOrganisationUpdatedMessage, FormOrganisationUpdatedMessageData, FormMetadata, FormCreatedMessage, FormCreatedMessageData, FormTitleUpdatedMessage, FormTeamNameUpdatedMessage, FormTeamNameUpdatedMessageData } from '@defra/forms-model'
  * @import { PartialFormMetadataDocument } from '~/src/api/types.js'
  */

--- a/src/messaging/mappers/form-events.test.js
+++ b/src/messaging/mappers/form-events.test.js
@@ -2,6 +2,7 @@ import { buildMetaData } from '@defra/forms-model/stubs'
 
 import {
   formOrganisationUpdatedMapper,
+  formTeamEmailUpdatedMapper,
   formTeamNameUpdatedMapper
 } from '~/src/messaging/mappers/form-events.js'
 
@@ -15,6 +16,12 @@ describe('form-events', () => {
   describe('formTeamNameUpdatedMapper', () => {
     it('should fail if teamName is missing', () => {
       expect(() => formTeamNameUpdatedMapper(buildMetaData(), {})).toThrow()
+    })
+  })
+
+  describe('formTeamEmailUpdatedMapper', () => {
+    it('should fail if teamEmail is missing', () => {
+      expect(() => formTeamEmailUpdatedMapper(buildMetaData(), {})).toThrow()
     })
   })
 })

--- a/src/messaging/mappers/form-events.test.js
+++ b/src/messaging/mappers/form-events.test.js
@@ -1,11 +1,20 @@
 import { buildMetaData } from '@defra/forms-model/stubs'
 
-import { formOrganisationUpdatedMapper } from '~/src/messaging/mappers/form-events.js'
+import {
+  formOrganisationUpdatedMapper,
+  formTeamNameUpdatedMapper
+} from '~/src/messaging/mappers/form-events.js'
 
 describe('form-events', () => {
   describe('formOrganisationUpdatedMapper', () => {
     it('should fail if organisation is missing', () => {
       expect(() => formOrganisationUpdatedMapper(buildMetaData(), {})).toThrow()
+    })
+  })
+
+  describe('formTeamNameUpdatedMapper', () => {
+    it('should fail if teamName is missing', () => {
+      expect(() => formTeamNameUpdatedMapper(buildMetaData(), {})).toThrow()
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DF-272
https://eaflood.atlassian.net/browse/DF-297

Stacked on https://github.com/DEFRA/forms-manager/pull/592