### PR TITLE
DF-301, 302, 303: Add support form submission guidance, privacy notice and notification email auditing

### DIFF
--- a/src/messaging/mappers/form-events-bulk.js
+++ b/src/messaging/mappers/form-events-bulk.js
@@ -1,5 +1,8 @@
 import {
+  formNotificationEmailUpdatedMapper,
   formOrganisationUpdatedMapper,
+  formPrivacyNoticeUpdatedMapper,
+  formSubmissionGuidanceUpdatedMapper,
   formTeamEmailUpdatedMapper,
   formTeamNameUpdatedMapper
 } from '~/src/messaging/mappers/form-events.js'
@@ -10,13 +13,19 @@ import {
 const mapperLookup = {
   organisation: formOrganisationUpdatedMapper,
   teamName: formTeamNameUpdatedMapper,
-  teamEmail: formTeamEmailUpdatedMapper
+  teamEmail: formTeamEmailUpdatedMapper,
+  notificationEmail: formNotificationEmailUpdatedMapper,
+  submissionGuidance: formSubmissionGuidanceUpdatedMapper,
+  privacyNoticeUrl: formPrivacyNoticeUpdatedMapper
 }
 
 const validFields = /** @type {(keyof PartialFormMetadataDocument)[]} */ ([
   'organisation',
   'teamName',
-  'teamEmail'
+  'teamEmail',
+  'notificationEmail',
+  'submissionGuidance',
+  'privacyNoticeUrl'
 ])
 
 const validKeys = /** @type {string[]} */ (validFields)

--- a/src/messaging/mappers/form-events-bulk.test.js
+++ b/src/messaging/mappers/form-events-bulk.test.js
@@ -15,6 +15,9 @@ describe('publish', () => {
   const organisation = 'Defra'
   const teamName = 'Forms'
   const teamEmail = 'forms@example.com'
+  const notificationEmail = 'notifyme@example.com'
+  const submissionGuidance = '# H1 Markdown'
+  const privacyNoticeUrl = 'https://www.gov.uk/help/privacy-notice'
   const createdAt = new Date('2025-07-23')
   const createdBy = {
     id: '83f09a7d-c80c-4e15-bcf3-641559c7b8a7',
@@ -27,6 +30,9 @@ describe('publish', () => {
     organisation,
     teamName,
     teamEmail,
+    notificationEmail,
+    submissionGuidance,
+    privacyNoticeUrl,
     createdAt,
     createdBy
   })
@@ -200,6 +206,117 @@ describe('publish', () => {
             },
             new: {
               teamEmail: 'newemail@example.com'
+            }
+          }
+        }
+      })
+    })
+
+    it('should get FORM_NOTIFICATION_EMAIL_UPDATED audit message', () => {
+      const updatedAt = new Date('2025-07-27')
+      const updatedBy = {
+        displayName: 'Gandalf',
+        id: '29a8b10d-1d7a-40d4-b312-c57f74e1a606'
+      }
+      const formUpdated = buildPartialFormMetadataDocument({
+        notificationEmail: 'newemail@example.com',
+        updatedBy,
+        updatedAt
+      })
+      const messages = getFormMetadataAuditMessages(metadata, formUpdated)
+      const [formUpdatedMessage] = messages
+      expect(messages).toHaveLength(1)
+      expect(formUpdatedMessage).toEqual({
+        entityId: formId,
+        messageCreatedAt: expect.any(Date),
+        schemaVersion: AuditEventMessageSchemaVersion.V1,
+        category: AuditEventMessageCategory.FORM,
+        type: AuditEventMessageType.FORM_NOTIFICATION_EMAIL_UPDATED,
+        createdAt: updatedAt,
+        createdBy: updatedBy,
+        data: {
+          formId,
+          slug: 'audit-form',
+          changes: {
+            previous: {
+              notificationEmail: 'notifyme@example.com'
+            },
+            new: {
+              notificationEmail: 'newemail@example.com'
+            }
+          }
+        }
+      })
+    })
+
+    it('should get FORM_SUBMISSION_GUIDANCE_UPDATED audit message', () => {
+      const updatedAt = new Date('2025-07-27')
+      const updatedBy = {
+        displayName: 'Gandalf',
+        id: '29a8b10d-1d7a-40d4-b312-c57f74e1a606'
+      }
+      const formUpdated = buildPartialFormMetadataDocument({
+        submissionGuidance: '## H2 Markdown',
+        updatedBy,
+        updatedAt
+      })
+      const messages = getFormMetadataAuditMessages(metadata, formUpdated)
+      const [formUpdatedMessage] = messages
+      expect(messages).toHaveLength(1)
+      expect(formUpdatedMessage).toEqual({
+        entityId: formId,
+        messageCreatedAt: expect.any(Date),
+        schemaVersion: AuditEventMessageSchemaVersion.V1,
+        category: AuditEventMessageCategory.FORM,
+        type: AuditEventMessageType.FORM_SUBMISSION_GUIDANCE_UPDATED,
+        createdAt: updatedAt,
+        createdBy: updatedBy,
+        data: {
+          formId,
+          slug: 'audit-form',
+          changes: {
+            previous: {
+              submissionGuidance: '# H1 Markdown'
+            },
+            new: {
+              submissionGuidance: '## H2 Markdown'
+            }
+          }
+        }
+      })
+    })
+
+    it('should get FORM_PRIVACY_NOTICE_UPDATED audit message', () => {
+      const updatedAt = new Date('2025-07-27')
+      const updatedBy = {
+        displayName: 'Gandalf',
+        id: '29a8b10d-1d7a-40d4-b312-c57f74e1a606'
+      }
+      const formUpdated = buildPartialFormMetadataDocument({
+        privacyNoticeUrl: 'https://www.gov.uk/help/new-privacy-notice',
+        updatedBy,
+        updatedAt
+      })
+      const messages = getFormMetadataAuditMessages(metadata, formUpdated)
+      const [formUpdatedMessage] = messages
+      expect(messages).toHaveLength(1)
+      expect(formUpdatedMessage).toEqual({
+        entityId: formId,
+        messageCreatedAt: expect.any(Date),
+        schemaVersion: AuditEventMessageSchemaVersion.V1,
+        category: AuditEventMessageCategory.FORM,
+        type: AuditEventMessageType.FORM_PRIVACY_NOTICE_UPDATED,
+        createdAt: updatedAt,
+        createdBy: updatedBy,
+        data: {
+          formId,
+          slug: 'audit-form',
+          changes: {
+            previous: {
+              privacyNoticeUrl: 'https://www.gov.uk/help/privacy-notice'
+            },
+            new: {
+              privacyNoticeUrl: 'https://www.gov.uk/help/new-privacy-notice'
             }
           }
         }

--- a/src/messaging/mappers/form-events.js
+++ b/src/messaging/mappers/form-events.js
@@ -191,6 +191,108 @@ export function formTeamEmailUpdatedMapper(metadata, updatedForm) {
 }
 
 /**
- * @import { FormTitleUpdatedMessageData, FormOrganisationUpdatedMessage, FormOrganisationUpdatedMessageData, FormMetadata, FormCreatedMessage, FormCreatedMessageData, FormTitleUpdatedMessage, FormTeamNameUpdatedMessage, FormTeamNameUpdatedMessageData, FormTeamEmailUpdatedMessage, FormTeamEmailUpdatedMessageData } from '@defra/forms-model'
+ * @param {FormMetadata} metadata
+ * @param {PartialFormMetadataDocument} updatedForm
+ * @returns {FormNotificationEmailUpdatedMessage}
+ */
+export function formNotificationEmailUpdatedMapper(metadata, updatedForm) {
+  const { notificationEmail: oldNotificationEmail } = metadata
+  const { notificationEmail } = updatedForm
+  const baseData = createFormMessageDataBase(metadata)
+
+  /**
+   * @type {FormNotificationEmailUpdatedMessageData}
+   */
+  const data = {
+    ...baseData,
+    changes: {
+      previous: {
+        notificationEmail: oldNotificationEmail
+      },
+      new: {
+        notificationEmail
+      }
+    }
+  }
+  const auditMessageBase = createV1MessageBase(metadata, updatedForm)
+
+  return {
+    ...auditMessageBase,
+    data,
+    category: AuditEventMessageCategory.FORM,
+    type: AuditEventMessageType.FORM_NOTIFICATION_EMAIL_UPDATED
+  }
+}
+
+/**
+ * @param {FormMetadata} metadata
+ * @param {PartialFormMetadataDocument} updatedForm
+ * @returns {FormSubmissionGuidanceUpdatedMessage}
+ */
+export function formSubmissionGuidanceUpdatedMapper(metadata, updatedForm) {
+  const { submissionGuidance: oldSubmissionGuidance } = metadata
+  const { submissionGuidance } = updatedForm
+  const baseData = createFormMessageDataBase(metadata)
+
+  /**
+   * @type {FormSubmissionGuidanceUpdatedMessageData}
+   */
+  const data = {
+    ...baseData,
+    changes: {
+      previous: {
+        submissionGuidance: oldSubmissionGuidance
+      },
+      new: {
+        submissionGuidance
+      }
+    }
+  }
+  const auditMessageBase = createV1MessageBase(metadata, updatedForm)
+
+  return {
+    ...auditMessageBase,
+    data,
+    category: AuditEventMessageCategory.FORM,
+    type: AuditEventMessageType.FORM_SUBMISSION_GUIDANCE_UPDATED
+  }
+}
+
+/**
+ * @param {FormMetadata} metadata
+ * @param {PartialFormMetadataDocument} updatedForm
+ * @returns {FormPrivacyNoticeUpdatedMessage}
+ */
+export function formPrivacyNoticeUpdatedMapper(metadata, updatedForm) {
+  const { privacyNoticeUrl: oldPrivacyNoticeUrl } = metadata
+  const { privacyNoticeUrl } = updatedForm
+  const baseData = createFormMessageDataBase(metadata)
+
+  /**
+   * @type {FormPrivacyNoticeUpdatedMessageData}
+   */
+  const data = {
+    ...baseData,
+    changes: {
+      previous: {
+        privacyNoticeUrl: oldPrivacyNoticeUrl
+      },
+      new: {
+        privacyNoticeUrl
+      }
+    }
+  }
+  const auditMessageBase = createV1MessageBase(metadata, updatedForm)
+
+  return {
+    ...auditMessageBase,
+    data,
+    category: AuditEventMessageCategory.FORM,
+    type: AuditEventMessageType.FORM_PRIVACY_NOTICE_UPDATED
+  }
+}
+
+/**
+ * @import { FormTitleUpdatedMessageData, FormOrganisationUpdatedMessage, FormOrganisationUpdatedMessageData, FormMetadata, FormCreatedMessage, FormCreatedMessageData, FormTitleUpdatedMessage, FormTeamNameUpdatedMessage, FormTeamNameUpdatedMessageData, FormTeamEmailUpdatedMessage, FormTeamEmailUpdatedMessageData, FormPrivacyNoticeUpdatedMessage, FormPrivacyNoticeUpdatedMessageData, FormSubmissionGuidanceUpdatedMessage, FormSubmissionGuidanceUpdatedMessageData, FormNotificationEmailUpdatedMessage, FormNotificationEmailUpdatedMessageData } from '@defra/forms-model'
  * @import { PartialFormMetadataDocument } from '~/src/api/types.js'
  */


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DF-301
https://eaflood.atlassian.net/browse/DF-302
https://eaflood.atlassian.net/browse/DF-303

Dependent on https://github.com/DEFRA/forms-designer/pull/1019