### PR TITLE
chore(DF-832): bump @defra/forms-model to 3.0.648 (DF-832)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
         "@aws-sdk/client-sns": "^3.995.0",
-        "@defra/forms-model": "^3.0.645",
+        "@defra/forms-model": "^3.0.648",
         "@defra/hapi-tracing": "^1.29.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.4.4",
@@ -2761,9 +2761,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.645",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.645.tgz",
-      "integrity": "sha512-7xzYkLxQ0qq57wN4woNBETleWliqEmdAY1N/gHO4tlYPceyysaRJNQbyss1NEWrKXdLxkPpclGu3VA2RS4dJ6Q==",
+      "version": "3.0.648",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.648.tgz",
+      "integrity": "sha512-hbQGF09vFI8Izpal2LiWIHNQbUJ4eqkQYcIcnEWDf8UpkB7qxB3LW2BQKGStjIYw4eiUz5Qus3uSG7R2skyZqA==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.995.0",
     "@aws-sdk/client-sns": "^3.995.0",
-    "@defra/forms-model": "^3.0.645",
+    "@defra/forms-model": "^3.0.648",
     "@defra/hapi-tracing": "^1.29.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.4.4",

--- a/src/api/forms/service/helpers/definition.test.js
+++ b/src/api/forms/service/helpers/definition.test.js
@@ -160,7 +160,7 @@ describe('definition helpers', () => {
       const definition = buildDefinition({ pages: [paymentPage] })
       const res = postSchemaValidation(definition)
       expect(res).toBeInstanceOf(Joi.ValidationError)
-      expect(res?.message).toBe('"value" must be greater than or equal to 0.3')
+      expect(res?.message).toBe('"value" must be greater than or equal to 0')
     })
 
     it('should return error if payment enabled but ref num disabled', () => {
@@ -190,8 +190,6 @@ describe('definition helpers', () => {
   describe('validatePaymentAmount', () => {
     it.each([
       { amount: -10, desc: 'negative' },
-      { amount: 0, desc: 'zero' },
-      { amount: 0.1, desc: 'below minimum (£0.30)' },
       { amount: 100_001, desc: 'above maximum (£100,000)' },
       { amount: NaN, desc: 'NaN' },
       { amount: Infinity, desc: 'Infinity' }
@@ -203,7 +201,9 @@ describe('definition helpers', () => {
     )
 
     it.each([
-      { amount: 0.3, desc: 'minimum boundary (£0.30)' },
+      { amount: 0, desc: 'zero / no payment (minimum boundary)' },
+      { amount: 0.1, desc: '£0.10' },
+      { amount: 0.3, desc: '£0.30' },
       { amount: 1, desc: '£1' },
       { amount: 100_000, desc: 'maximum boundary (£100,000)' }
     ])(


### PR DESCRIPTION
Picks up [DF-832 ](https://eaflood.atlassian.net/browse/DF-831?atlOrigin=eyJpIjoiZTRhNWRhNGExZjE0NDMxNWEwMWZiMmQ3YzU1YWNmOWYiLCJwIjoiaiJ9)payment changes from `@defra/forms-model`:

- [forms-designer#1384](https://github.com/DEFRA/forms-designer/pull/1384) — `feat(model): add conditional amounts and email prepopulation to PaymentField`
- [forms-designer#1397](https://github.com/DEFRA/forms-designer/pull/1397) — `fix(model): update paymentAmountSchema min to 0`

Enables `forms-manager` to accept PaymentField forms with:
- `options.amount: 0` — no payment by default (previously rejected by `validatePaymentAmount()` in `postSchemaValidation` with `"value" must be greater than or equal to 0.3`)
- `options.conditionalAmounts[]` — condition-based payment amounts (first match wins, conditional amounts still enforce `min(0.3)`)
- `options.emailField` — EmailAddressField name for GOV.UK Pay email prepopulation

[DF-832](https://eaflood.atlassian.net/browse/DF-831?atlOrigin=eyJpIjoiZTRhNWRhNGExZjE0NDMxNWEwMWZiMmQ3YzU1YWNmOWYiLCJwIjoiaiJ9)

[DF-832]: https://eaflood.atlassian.net/browse/DF-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ