### PR TITLE
feat/df-1091: Metrics enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
         "@aws-sdk/client-sns": "^3.995.0",
-        "@defra/forms-model": "^3.0.648",
+        "@defra/forms-model": "^3.0.664",
         "@defra/hapi-tracing": "^1.29.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.4.4",
@@ -2761,9 +2761,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.648",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.648.tgz",
-      "integrity": "sha512-hbQGF09vFI8Izpal2LiWIHNQbUJ4eqkQYcIcnEWDf8UpkB7qxB3LW2BQKGStjIYw4eiUz5Qus3uSG7R2skyZqA==",
+      "version": "3.0.664",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.664.tgz",
+      "integrity": "sha512-d4flS+TKPbxpynQpZ45d1MCTfluBCYnfVbObtYqGBpJXy3u344U8Zon7oN6fyotm5ExGDN+h99cE33lMvzcsxQ==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.995.0",
     "@aws-sdk/client-sns": "^3.995.0",
-    "@defra/forms-model": "^3.0.648",
+    "@defra/forms-model": "^3.0.664",
     "@defra/hapi-tracing": "^1.29.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.4.4",

--- a/src/api/forms/service/__stubs__/metrics.js
+++ b/src/api/forms/service/__stubs__/metrics.js
@@ -69,7 +69,8 @@ export function getExpectedOverviewMetrics(timestamp) {
           ...expectedBaseSummaryMetrics,
           name: 'Form 3 title',
           slug: 'form-3-title',
-          status: 'draft'
+          status: 'draft',
+          sections: 0
         },
         featureMetrics: {
           features: {},

--- a/src/api/forms/service/report-overview.js
+++ b/src/api/forms/service/report-overview.js
@@ -170,17 +170,15 @@ export function calcFeatureMetrics(definition) {
     }
     // Special case - if declaration in CYA page, remove the Markdown component,
     // and add 'Declaration in CYA' component to totals
-    if (isSummaryPage(page)) {
-      if (hasDeclarationInCYA(definition)) {
-        const markdownPos = allComponents.findIndex(
-          (comp) => comp.type === ComponentType.Markdown
-        )
-        if (markdownPos > -1) {
-          allComponents.splice(markdownPos, 1)
-          // @ts-expect-error - 'DeclarationInCYA' is not strictly in the enum of ComponentType
-          // but we want a separate value for metrics display purposes
-          allComponents.push({ type: 'DeclarationInCYA' })
-        }
+    if (isSummaryPage(page) && hasDeclarationInCYA(definition)) {
+      const markdownPos = allComponents.findIndex(
+        (comp) => comp.type === ComponentType.Markdown
+      )
+      if (markdownPos > -1) {
+        allComponents.splice(markdownPos, 1)
+        // @ts-expect-error - 'DeclarationInCYA' is not strictly in the enum of ComponentType
+        // but we want a separate value for metrics display purposes
+        allComponents.push({ type: 'DeclarationInCYA' })
       }
     }
   }
@@ -309,22 +307,18 @@ export function getUniqueComponentTypes(definition) {
  * @param {FormDefinition} definition
  */
 export function getUniqueAssignedConditions(definition) {
-  const conditions = new Set()
-  definition.pages
-    .filter((p) => p.condition)
-    .forEach((p2) => conditions.add(p2.condition))
-  return conditions
+  return new Set(
+    definition.pages.filter((p) => p.condition).map((p2) => p2.condition)
+  )
 }
 
 /**
  * @param {FormDefinition} definition
  */
 export function getUniqueAssignedSections(definition) {
-  const sections = new Set()
-  definition.pages
-    .filter((p) => p.section)
-    .forEach((p2) => sections.add(p2.section))
-  return sections
+  return new Set(
+    definition.pages.filter((p) => p.section).map((p2) => p2.section)
+  )
 }
 
 /**

--- a/src/api/forms/service/report-overview.js
+++ b/src/api/forms/service/report-overview.js
@@ -6,7 +6,9 @@ import {
   getErrorMessage,
   hasComponentsEvenIfNoNext,
   hasPaymentQuestionInForm,
-  hasSpecificQuestionTypeInForm
+  hasPostcodeLookupInForm,
+  hasSpecificQuestionTypeInForm,
+  isSummaryPage
 } from '@defra/forms-model'
 import { StatusCodes } from 'http-status-codes'
 
@@ -151,8 +153,8 @@ export function calcSummaryMetrics(metadata, definition, definitionType) {
     status: definitionType,
     pages: definition.pages.length,
     questionTypes: getUniqueComponentTypes(definition).size,
-    conditions: definition.conditions.length,
-    sections: definition.sections.length,
+    conditions: getUniqueAssignedConditions(definition).size,
+    sections: getUniqueAssignedSections(definition).size,
     features: getFeatureList(definition)
   })
 }
@@ -166,7 +168,23 @@ export function calcFeatureMetrics(definition) {
     if (hasComponentsEvenIfNoNext(page)) {
       allComponents.push(...page.components)
     }
+    // Special case - if declaration in CYA page, remove the Markdown component,
+    // and add 'Declaration in CYA' component to totals
+    if (isSummaryPage(page)) {
+      if (hasDeclarationInCYA(definition)) {
+        const markdownPos = allComponents.findIndex(
+          (comp) => comp.type === ComponentType.Markdown
+        )
+        if (markdownPos > -1) {
+          allComponents.splice(markdownPos, 1)
+          // @ts-expect-error - 'DeclarationInCYA' is not strictly in the enum of ComponentType
+          // but we want a separate value for metrics display purposes
+          allComponents.push({ type: 'DeclarationInCYA' })
+        }
+      }
+    }
   }
+
   const questionTypes = getQuestionTypeCounts(allComponents)
   return {
     questionTypes: Object.fromEntries(questionTypes),
@@ -192,10 +210,10 @@ export function getQuestionTypeCounts(components) {
  */
 export function getComponentUsageFeatureMetrics(definition) {
   const features = getFeatureList(definition)
-  if (definition.pages.some((p) => p.section)) {
+  if (getUniqueAssignedSections(definition).size) {
     features.push('Sections')
   }
-  if (definition.pages.some((p) => p.condition)) {
+  if (getUniqueAssignedConditions(definition).size) {
     features.push('Conditional logic')
   }
   const featureResult = /** @type {Record<string, number>} */ ({})
@@ -218,10 +236,23 @@ export function getFormStructureCounts(definition, questionTypes) {
   return {
     pages: definition.pages.length,
     questions: numOfQuestions,
-    sections: definition.pages.filter((p) => p.section).length,
-    conditions: definition.pages.filter((p) => p.condition).length,
+    sections: getUniqueAssignedSections(definition).size,
+    conditions: getUniqueAssignedConditions(definition).size,
     questionTypes: questionTypes.size
   }
+}
+
+/**
+ * @param {FormDefinition} definition
+ */
+export function hasDeclarationInCYA(definition) {
+  const summaryPage = definition.pages.find((pg) => isSummaryPage(pg))
+  const markdown = hasComponentsEvenIfNoNext(summaryPage)
+    ? summaryPage.components.find(
+        (comp, idx) => comp.type === ComponentType.Markdown && idx === 0
+      )
+    : undefined
+  return markdown !== undefined
 }
 
 /**
@@ -247,13 +278,21 @@ export function getFeatureList(definition) {
   if (
     hasSpecificQuestionTypeInForm(definition, ComponentType.DeclarationField)
   ) {
-    features.push('Declarations')
+    features.push('Declaration field')
+  }
+  if (hasDeclarationInCYA(definition)) {
+    features.push('Declaration in CYA')
+  }
+  if (hasPostcodeLookupInForm(definition)) {
+    features.push('Postcode lookup')
+  }
+  if (definition.options?.showReferenceNumber) {
+    features.push('Reference number')
   }
   return features
 }
 
 /**
- *
  * @param {FormDefinition} definition
  */
 export function getUniqueComponentTypes(definition) {
@@ -264,6 +303,28 @@ export function getUniqueComponentTypes(definition) {
     }
   }
   return componentTypes
+}
+
+/**
+ * @param {FormDefinition} definition
+ */
+export function getUniqueAssignedConditions(definition) {
+  const conditions = new Set()
+  definition.pages
+    .filter((p) => p.condition)
+    .forEach((p2) => conditions.add(p2.condition))
+  return conditions
+}
+
+/**
+ * @param {FormDefinition} definition
+ */
+export function getUniqueAssignedSections(definition) {
+  const sections = new Set()
+  definition.pages
+    .filter((p) => p.section)
+    .forEach((p2) => sections.add(p2.section))
+  return sections
 }
 
 /**

--- a/src/api/forms/service/report-overview.test.js
+++ b/src/api/forms/service/report-overview.test.js
@@ -1,4 +1,4 @@
-import { ControllerType, FormStatus } from '@defra/forms-model'
+import { ComponentType, ControllerType, FormStatus } from '@defra/forms-model'
 import {
   buildCheckboxComponent,
   buildDeclarationFieldComponent,
@@ -437,6 +437,85 @@ describe('report-overview', () => {
           CheckboxesField: 2,
           DeclarationField: 1,
           FileUploadField: 1,
+          PaymentField: 1,
+          RadiosField: 1,
+          TextField: 3
+        }
+      })
+    })
+
+    it('should handle declaration in CYA page', () => {
+      const summaryPage = buildSummaryPage({
+        // @ts-expect-error - forcing the controller type
+        controller: ControllerType.SummaryWithConfirmationEmail,
+        components: [
+          {
+            type: ComponentType.Markdown,
+            content: 'My declaration',
+            title: 'Declaration',
+            name: 'decl',
+            options: {}
+          }
+        ]
+      })
+      const questionPageId = 'd9c99072-d25d-4688-ab7d-3822cffe802b'
+      const questionPage = buildQuestionPage({
+        id: questionPageId,
+        components: [
+          buildTextFieldComponent(),
+          buildTextFieldComponent(),
+          buildMarkdownComponent(),
+          buildMarkdownComponent(),
+          buildCheckboxComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildRadioComponent(),
+          buildDeclarationFieldComponent()
+        ]
+      })
+      const fileUploadPage = buildFileUploadPage()
+      const paymentPage = buildQuestionPage({
+        components: [buildPaymentComponent()]
+      })
+      const sectionPage1 = buildQuestionPage({
+        section: 'some-section-id1'
+      })
+      const sectionPage2 = buildQuestionPage({
+        section: 'some-section-id2'
+      })
+
+      const definition = buildDefinition({
+        pages: [
+          questionPage,
+          fileUploadPage,
+          sectionPage1,
+          sectionPage2,
+          paymentPage,
+          summaryPage
+        ]
+      })
+      expect(calcFeatureMetrics(definition)).toEqual({
+        features: {
+          'File upload': 1,
+          'Email confirmation': 1,
+          'GOV.UK Pay': 1,
+          'Declaration field': 1,
+          'Declaration in CYA': 1,
+          Sections: 1
+        },
+        formStructure: {
+          conditions: 0,
+          pages: 6,
+          questionTypes: 8,
+          questions: 12,
+          sections: 2
+        },
+        questionTypes: {
+          CheckboxesField: 2,
+          DeclarationField: 1,
+          DeclarationInCYA: 1,
+          FileUploadField: 1,
+          Markdown: 2,
           PaymentField: 1,
           RadiosField: 1,
           TextField: 3

--- a/src/api/forms/service/report-overview.test.js
+++ b/src/api/forms/service/report-overview.test.js
@@ -3,8 +3,10 @@ import {
   buildCheckboxComponent,
   buildDeclarationFieldComponent,
   buildFileUploadPage,
+  buildMarkdownComponent,
   buildPaymentComponent,
-  buildRadioComponent
+  buildRadioComponent,
+  buildUkAddressFieldComponent
 } from '@defra/forms-model/stubs'
 import Boom from '@hapi/boom'
 import { ObjectId } from 'mongodb'
@@ -26,6 +28,8 @@ import {
   getDefinitionIfExists,
   getFeatureList,
   getQuestionTypeCounts,
+  getUniqueAssignedConditions,
+  getUniqueAssignedSections,
   getUniqueComponentTypes
 } from '~/src/api/forms/service/report-overview.js'
 import { client } from '~/src/mongo.js'
@@ -209,6 +213,118 @@ describe('report-overview', () => {
     })
   })
 
+  describe('getUniqueAssignedConditions', () => {
+    it('should return empty list', () => {
+      const summaryPage = buildSummaryPage()
+      const questionPageId = 'd9c99072-d25d-4688-ab7d-3822cffe802b'
+      const questionPage = buildQuestionPage({
+        id: questionPageId
+      })
+
+      const definition = buildDefinition({
+        pages: [questionPage, summaryPage]
+      })
+      expect(getUniqueAssignedConditions(definition)).toEqual(new Set())
+    })
+
+    it('should return unique list', () => {
+      const summaryPage = buildSummaryPage()
+      const questionPageId = 'd9c99072-d25d-4688-ab7d-3822cffe802b'
+      const questionPage1 = buildQuestionPage({
+        id: questionPageId,
+        components: [
+          buildTextFieldComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildRadioComponent()
+        ],
+        condition: 'cond1'
+      })
+      const questionPage2 = buildQuestionPage({
+        id: questionPageId,
+        components: [
+          buildTextFieldComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildRadioComponent()
+        ],
+        condition: 'cond1'
+      })
+      const questionPage3 = buildQuestionPage({
+        id: questionPageId,
+        components: [buildTextFieldComponent(), buildTextFieldComponent()],
+        condition: 'cond2'
+      })
+
+      const definition = buildDefinition({
+        pages: [questionPage1, questionPage2, questionPage3, summaryPage]
+      })
+      expect(getUniqueAssignedConditions(definition)).toEqual(
+        new Set(['cond1', 'cond2'])
+      )
+    })
+  })
+
+  describe('getUniqueAssignedSections', () => {
+    it('should return empty list', () => {
+      const summaryPage = buildSummaryPage()
+      const questionPageId = 'd9c99072-d25d-4688-ab7d-3822cffe802b'
+      const questionPage = buildQuestionPage({
+        id: questionPageId
+      })
+
+      const definition = buildDefinition({
+        pages: [questionPage, summaryPage]
+      })
+      expect(getUniqueAssignedSections(definition)).toEqual(new Set())
+    })
+
+    it('should return unique list', () => {
+      const summaryPage = buildSummaryPage()
+      const questionPageId = 'd9c99072-d25d-4688-ab7d-3822cffe802b'
+      const questionPage1 = buildQuestionPage({
+        id: questionPageId,
+        components: [
+          buildTextFieldComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildRadioComponent()
+        ],
+        section: 'sect1'
+      })
+      const questionPage2 = buildQuestionPage({
+        id: questionPageId,
+        components: [
+          buildTextFieldComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildTextFieldComponent(),
+          buildCheckboxComponent(),
+          buildRadioComponent()
+        ],
+        section: 'sect2'
+      })
+      const questionPage3 = buildQuestionPage({
+        id: questionPageId,
+        components: [buildTextFieldComponent(), buildTextFieldComponent()],
+        section: 'sect2'
+      })
+
+      const definition = buildDefinition({
+        pages: [questionPage1, questionPage2, questionPage3, summaryPage]
+      })
+      expect(getUniqueAssignedSections(definition)).toEqual(
+        new Set(['sect1', 'sect2'])
+      )
+    })
+  })
+
   describe('getFeatureList', () => {
     it('should return empty list', () => {
       const summaryPage = buildSummaryPage()
@@ -226,7 +342,8 @@ describe('report-overview', () => {
     it('should return unique list', () => {
       const summaryPage = buildSummaryPage({
         // @ts-expect-error - forcing the controller type
-        controller: ControllerType.SummaryWithConfirmationEmail
+        controller: ControllerType.SummaryWithConfirmationEmail,
+        components: [buildMarkdownComponent()]
       })
       const questionPageId = 'd9c99072-d25d-4688-ab7d-3822cffe802b'
       const questionPage = buildQuestionPage({
@@ -247,13 +364,16 @@ describe('report-overview', () => {
       })
 
       const definition = buildDefinition({
-        pages: [questionPage, fileUploadPage, paymentPage, summaryPage]
+        pages: [questionPage, fileUploadPage, paymentPage, summaryPage],
+        options: { showReferenceNumber: true }
       })
       expect(getFeatureList(definition)).toEqual([
         'File upload',
         'Email confirmation',
         'GOV.UK Pay',
-        'Declarations'
+        'Declaration field',
+        'Declaration in CYA',
+        'Reference number'
       ])
     })
   })
@@ -303,7 +423,7 @@ describe('report-overview', () => {
           'File upload': 1,
           'Email confirmation': 1,
           'GOV.UK Pay': 1,
-          Declarations: 1,
+          'Declaration field': 1,
           Sections: 1
         },
         formStructure: {
@@ -378,12 +498,18 @@ describe('report-overview', () => {
       const sectionPage = buildQuestionPage({
         section: 'some-section-id'
       })
+      const postcodeLookupPage = buildQuestionPage({
+        components: [
+          buildUkAddressFieldComponent({ options: { usePostcodeLookup: true } })
+        ]
+      })
 
       const definition = buildDefinition({
         pages: [
           questionPage,
           fileUploadPage,
           paymentPage,
+          postcodeLookupPage,
           conditionPage,
           sectionPage,
           summaryPage
@@ -393,9 +519,10 @@ describe('report-overview', () => {
         'File upload': 1,
         'Email confirmation': 1,
         'GOV.UK Pay': 1,
-        Declarations: 1,
+        'Declaration field': 1,
         Sections: 1,
-        'Conditional logic': 1
+        'Conditional logic': 1,
+        'Postcode lookup': 1
       })
     })
   })


### PR DESCRIPTION
Adds the following features:
- Declaration field
- Declaration in CYA (if the Markdown component is in the Summary page denoting a Declaration, the count subtracts 1 from Markdown)
- Reference number
- Postcode lookup

The counts for 'conditions' and 'sections' are now calculated based on unique conditions/sections assigned rather than simply how many are in the conditions/sections array

NOTE - needs a model bump when designer PR https://github.com/DEFRA/forms-designer/pull/1440 is merged 

Ticket [DF-1091](https://eaflood.atlassian.net/browse/DF-1091)

[DF-1091]: https://eaflood.atlassian.net/browse/DF-1091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ