### PR TITLE
feat/df-1064: Prevents go-live if translations missing or out-of-sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@aws-sdk/client-s3": "^3.1062.0",
         "@aws-sdk/client-sns": "^3.1062.0",
         "@aws-sdk/credential-providers": "3.1073.0",
-        "@defra/forms-model": "^3.0.686",
+        "@defra/forms-model": "^3.0.688",
         "@defra/hapi-tracing": "^1.30.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/hapi": "^21.4.9",
@@ -2499,9 +2499,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.686",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.686.tgz",
-      "integrity": "sha512-OJnEtOoS3AZKSEoH2q2ALepniwsyDCBHsJWBzcY3isVOcNX74PSWyIVP4Nv03jVeyLM+6F0P39HEFlWK7qVEmA==",
+      "version": "3.0.688",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.688.tgz",
+      "integrity": "sha512-g5NyU/aqfAz9WqydiAV1bvMR++CU4GbdtPOc1HoNuuv/tkpKxMhjr8idjpKDZwzr0migzgm73ARPb99EQ4jORg==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@aws-sdk/client-s3": "^3.1062.0",
     "@aws-sdk/client-sns": "^3.1062.0",
     "@aws-sdk/credential-providers": "3.1073.0",
-    "@defra/forms-model": "^3.0.686",
+    "@defra/forms-model": "^3.0.688",
     "@defra/hapi-tracing": "^1.30.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/hapi": "^21.4.9",

--- a/src/api/forms/constants.js
+++ b/src/api/forms/constants.js
@@ -14,7 +14,11 @@ export const makeFormLiveErrorMessages = {
   missingTermsAndConditions:
     'You must confirm you meet the terms and conditions before you make this form live.',
   missingLivePaymentApiKey:
-    'You must add a valid live payment API key before you make this form live.'
+    'You must add a valid live payment API key before you make this form live.',
+  missingTranslations:
+    'You must finish translating the whole form into Welsh before making this form live.',
+  outOfSyncTranslations:
+    'You have made changes to the form that have affected Welsh translations. You must re-save the Welsh translations.'
 }
 
 export const removeFormErrorMessages = {

--- a/src/api/forms/service/definition.js
+++ b/src/api/forms/service/definition.js
@@ -2,6 +2,7 @@ import {
   Engine,
   FormDefinitionRequestType,
   FormStatus,
+  buildTranslationDataRows,
   getErrorMessage,
   isPaymentPage
 } from '@defra/forms-model'
@@ -193,6 +194,43 @@ function missingTermsAndConditions(form) {
 }
 
 /**
+ * @param {FormMetadata} form
+ * @param {FormDefinition} definition
+ */
+function checkForMissingTranslations(form, definition) {
+  // Ignore if no translations
+  // @ts-expect-error - dynamic language name
+  if (!definition.metadata?.translations?.cy) {
+    return
+  }
+
+  // @ts-expect-error - dynamic language name
+  const cy = definition.metadata.translations.cy
+
+  // Check if translation entries are in sync with form definition
+  const translations = buildTranslationDataRows(form, definition)
+  const combinedRows = translations.overviewRows.concat(translations.formRows)
+  const expectedKeys = new Set(combinedRows.map((row) => row.name))
+  const foundKeys = new Set(Object.keys(cy))
+
+  const added = [...foundKeys].filter((v) => !expectedKeys.has(v))
+  const removed = [...expectedKeys].filter((v) => !foundKeys.has(v))
+
+  if (added.length || removed.length || foundKeys.size !== expectedKeys.size) {
+    throw Boom.badRequest(makeFormLiveErrorMessages.outOfSyncTranslations)
+  }
+
+  // Check for any empty translations
+  const hasEmptyValues = Object.entries(
+    // @ts-expect-error - dynamic language name
+    definition.metadata.translations.cy
+  ).some(([, value]) => !value)
+  if (hasEmptyValues) {
+    throw Boom.badRequest(makeFormLiveErrorMessages.missingTranslations)
+  }
+}
+
+/**
  * Validates form and form definition for publishing to live
  * @param {string} formId - ID of the form
  * @param {FormMetadata} form - Form metadata
@@ -251,6 +289,8 @@ function validateFormForPublishing(
   if (!form.notificationEmail) {
     throw Boom.badRequest(makeFormLiveErrorMessages.missingOutputEmail)
   }
+
+  checkForMissingTranslations(form, draftFormDefinition)
 }
 
 /**

--- a/src/api/forms/service/definition.test.js
+++ b/src/api/forms/service/definition.test.js
@@ -424,6 +424,55 @@ describe('Forms service', () => {
       )
     })
 
+    it('should fail to create a live state from existing draft form when the Welsh translations are out of sync', async () => {
+      jest.mocked(formMetadata.get).mockResolvedValue(formMetadataDocument)
+
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(
+        /** @type {FormDefinition} */ ({
+          ...definition,
+          metadata: {
+            translations: {
+              cy: {
+                'form.title': 'Welsh form title'
+              }
+            }
+          }
+        })
+      )
+
+      await expect(createLiveFromDraft(id, author)).rejects.toThrow(
+        Boom.badRequest(makeFormLiveErrorMessages.outOfSyncTranslations)
+      )
+    })
+
+    it('should fail to create a live state from existing draft form when the Welsh translations are not fully completed', async () => {
+      jest.mocked(formMetadata.get).mockResolvedValue(formMetadataDocument)
+
+      jest.mocked(formDefinition.get).mockResolvedValueOnce(
+        /** @type {FormDefinition} */ ({
+          ...definition,
+          metadata: {
+            translations: {
+              cy: {
+                'form.title': 'Welsh form title',
+                'form.contact.email.address': 'my-email@test.com',
+                'form.contact.email.responseTime': 'Welsh response time',
+                'form.contact.online.url': 'https://welsh-contact.org',
+                'form.contact.online.text': 'Welsh contact text',
+                'form.contact.phone': 'Welsh phone',
+                'form.submissionGuidance': 'Welsh submission guidance',
+                'form.privacyNoticeUrl': ''
+              }
+            }
+          }
+        })
+      )
+
+      await expect(createLiveFromDraft(id, author)).rejects.toThrow(
+        Boom.badRequest(makeFormLiveErrorMessages.missingTranslations)
+      )
+    })
+
     it('should succeed to create a live state from existing draft form when there is no start page when engine is V2', async () => {
       const draftV2DefinitionNoStartPage = /** @type {FormDefinition} */ ({
         ...definition,


### PR DESCRIPTION
Prevents go-live if translations missing or out-of-sync

Depends on the merge of https://github.com/DEFRA/forms-designer/pull/1520

Two different error messages depending if either:
- the translations are out of sync (you made form changes and didn't revisit the translations page)
- you have not fully completed the translations (some fields are still empty)